### PR TITLE
fix(directive): make it work even mask is empty

### DIFF
--- a/src/app/ngx-mask/mask.directive.spec.ts
+++ b/src/app/ngx-mask/mask.directive.spec.ts
@@ -281,4 +281,13 @@ describe('Directive: Mask', () => {
     equal('1éáa2aaaaqwo', '12');
     equal('1234567', '1234.567');
   });
+
+  it('should work even has no mask', () => {
+    component.mask = '';
+
+    equal('1234567', '1234567');
+
+    expect(component.form.value)
+      .toBe('1234567');
+  });
 });

--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -62,10 +62,13 @@ export class MaskDirective {
 
   @HostListener('input', ['$event'])
   public onInput(e: KeyboardEvent): void {
+    const el: HTMLInputElement = (e.target as HTMLInputElement);
+
     if (!this._maskValue) {
+      this._maskService.onChange(el.value);
       return;
     }
-    const el: HTMLInputElement = (e.target as HTMLInputElement);
+
     const position: number = el.selectionStart;
 
     let caretShift: number = 0;


### PR DESCRIPTION
When `mask=""` ngx-mask not forward input value to form control at all. And when we call `this.form.value` it will be `undefined` and make the form completely useless.

I usually wrap an input in a component (eg `TextField` or `FormField` ) and control its state from there, then pass mask value down to the input. This sometimes make the input has an empty mask on non-masked fields and ngx-mask won't allow that.

Hope this help,
Porawit Poboonma