### PR TITLE
Fixing IE11 browser hang issue

### DIFF
--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -22,7 +22,8 @@ export class MaskDirective {
   private _maskValue: string;
 
   public constructor(
-    @Inject(DOCUMENT) private document: Document,
+    // tslint:disable-next-line
+    @Inject(DOCUMENT) private document: any,
     private _maskService: MaskService,
   ) { }
 

--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -1,9 +1,10 @@
 import {
-  Directive, HostListener, Input
+  Directive, HostListener, Inject, Input
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MaskService } from './mask.service';
 import { IConfig } from './config';
+import { DOCUMENT } from '@angular/common';
 
 @Directive({
   selector: '[mask]',
@@ -21,6 +22,7 @@ export class MaskDirective {
   private _maskValue: string;
 
   public constructor(
+    @Inject(DOCUMENT) private document: Document,
     private _maskService: MaskService,
   ) { }
 
@@ -76,12 +78,16 @@ export class MaskDirective {
       position,
       (shift: number) => caretShift = shift
     );
-    el.selectionStart = el.selectionEnd = position + (
-      // tslint:disable-next-line
-      (e as any).inputType === 'deleteContentBackward'
-        ? 0
-        : caretShift
-    );
+
+    // only set the selection if the element is active
+    if (this.document.activeElement === el) {
+      el.selectionStart = el.selectionEnd = position + (
+        // tslint:disable-next-line
+        (e as any).inputType === 'deleteContentBackward'
+          ? 0
+          : caretShift
+      );
+    }
   }
 
   @HostListener('blur')

--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -1,10 +1,10 @@
 import {
   Directive, HostListener, Inject, Input
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MaskService } from './mask.service';
 import { IConfig } from './config';
-import { DOCUMENT } from '@angular/common';
 
 @Directive({
   selector: '[mask]',


### PR DESCRIPTION
In IE 11 if I have multiple inputs with masks and I focus the first input and then focus the second, the two inputs keep focusing by themselves over and over again in an infinite loop causing the browser to hang:

![](https://i.gyazo.com/58f4f8bb0071a9cf9ec41fec5dd42120.gif)

You can see an example of the issue here is viewed in IE11:

https://stackblitz.com/edit/ngx-mask-issue?file=app/app.component.html

The issue is that setting the selectionStart & selectionEnd is triggering the input event to be fired again. I have added a check to only set the selection points if the element is the activeElement.