### PR TITLE
Add precision checks to the dot_separator and comma_separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ Input value: 1234.56
 Masked value: 1,234.56
 ```
 
+```html
+ <input type='text' mask="dot_separator.2">
+ <input type='text' mask="coma_separator.2">
+ <input type='text' mask="dot_separator.0">
+ <input type='text' mask="coma_separator.0">
+```
+For limiting decimal precision add '.' and the precision you want to limit too on the input. 2 is useful for currency. 0 will prevent decimals completely. 
+
+```
+Input value: 1234,56
+Masked value: 1.234,56
+
+Input value: 1234.56
+Masked value: 1,234.56
+
+Input value: 1234,56
+Masked value: 1.234
+
+Input value: 1234.56
+Masked value: 1,234
+```
+
 ### Time validation
   You can validate your input as 24 hour format
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -391,14 +391,14 @@
             <mat-card-header>
               <mat-card-title>Thousand separator mask</mat-card-title>
               <mat-card-subtitle>
-                You can devide your input by thousands
+                You can divide your input by thousands
               </mat-card-subtitle>
             </mat-card-header>
             <mat-card-content>
               <div class="flex-row">
                 <div class="flex-cell-padding">
                   <mat-form-field>
-                    <input matInput placeholder="Separator" mask="coma_separator" [formControl]="separatorForm" [(ngModel)]="separatorFormModel">
+                    <input matInput placeholder="Separator" mask="separator" [formControl]="separatorForm" [(ngModel)]="separatorFormModel">
                     <mat-hint><b>Mask: </b>separator</mat-hint>
                   </mat-form-field>
                 </div>
@@ -406,6 +406,96 @@
                     <p><b>FormControl:</b> {{ separatorForm.value ? separatorForm.value: 'Empty' }}</p>
                     <p><b>NgModel:</b> {{ separatorFormModel ? separatorFormModel: 'Empty' }}</p>
                   </div>
+              </div>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" mask="dot_separator" [formControl]="dotSeparatorForm" [(ngModel)]="dotSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>dot_separator</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ dotSeparatorForm.value ? dotSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ dotSeparatorFormModel ? dotSeparatorFormModel: 'Empty' }}</p>
+                </div>
+              </div>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" mask="coma_separator" [formControl]="commaSeparatorForm" [(ngModel)]="commaSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>coma_separator</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ commaSeparatorForm.value ? commaSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ commaSeparatorFormModel ? commaSeparatorFormModel: 'Empty' }}</p>
+                </div>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        <div class="mat-card-wr">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>Separator precision</mat-card-title>
+              <mat-card-subtitle>
+                You can set the precision for dot and comma separators
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" mask="dot_separator.2" [formControl]="dotPrecisionSeparatorForm" [(ngModel)]="dotPrecisionSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>dot_separator.2</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ dotPrecisionSeparatorForm.value ? dotPrecisionSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ dotPrecisionSeparatorFormModel ? dotPrecisionSeparatorFormModel: 'Empty' }}</p>
+                </div>
+              </div>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" [dropSpecialCharacters]="[',']" mask="coma_separator.2" [formControl]="commaPrecisionSeparatorForm" [(ngModel)]="commaPrecisionSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>coma_separator.2</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ commaPrecisionSeparatorForm.value ? commaPrecisionSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ commaPrecisionSeparatorFormModel ? commaPrecisionSeparatorFormModel: 'Empty' }}</p>
+                </div>
+              </div>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" mask="dot_separator.0" [formControl]="dotZeroPrecisionSeparatorForm" [(ngModel)]="dotZeroPrecisionSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>dot_separator.0</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ dotZeroPrecisionSeparatorForm.value ? dotZeroPrecisionSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ dotZeroPrecisionSeparatorFormModel ? dotZeroPrecisionSeparatorFormModel: 'Empty' }}</p>
+                </div>
+              </div>
+              <div class="flex-row">
+                <div class="flex-cell-padding">
+                  <mat-form-field>
+                    <input matInput placeholder="Separator" mask="coma_separator.0" [formControl]="commaZeroPrecisionSeparatorForm" [(ngModel)]="commaZeroPrecisionSeparatorFormModel">
+                    <mat-hint><b>Mask: </b>coma_separator.0</mat-hint>
+                  </mat-form-field>
+                </div>
+                <div class="flex-cell">
+                  <p><b>FormControl:</b> {{ commaZeroPrecisionSeparatorForm.value ? commaZeroPrecisionSeparatorForm.value: 'Empty' }}</p>
+                  <p><b>NgModel:</b> {{ commaZeroPrecisionSeparatorFormModel ? commaZeroPrecisionSeparatorFormModel: 'Empty' }}</p>
+                </div>
               </div>
             </mat-card-content>
           </mat-card>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,9 +44,10 @@ export class AppComponent {
   public commaZeroPrecisionSeparatorFormModel: string | number;
   private dotSeparatorForm: FormControl;
   private dotPrecisionSeparatorForm: FormControl;
-
+  private dotZeroPrecisionSeparatorForm: FormControl;
   private commaSeparatorForm: FormControl;
   private commaPrecisionSeparatorForm: FormControl;
+  private commaZeroPrecisionSeparatorForm: FormControl;
 
   public constructor() {
     this.form = new FormControl('');

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,17 @@ export class AppComponent {
   public sufixModel: string | number;
   public repeatFormModel: string | number;
   public separatorFormModel: string | number;
+  public dotSeparatorFormModel: string | number;
+  public dotPrecisionSeparatorFormModel: string | number;
+  public dotZeroPrecisionSeparatorFormModel: string | number;
+  public commaSeparatorFormModel: string | number;
+  public commaPrecisionSeparatorFormModel: string | number;
+  public commaZeroPrecisionSeparatorFormModel: string | number;
+  private dotSeparatorForm: FormControl;
+  private dotPrecisionSeparatorForm: FormControl;
+
+  private commaSeparatorForm: FormControl;
+  private commaPrecisionSeparatorForm: FormControl;
 
   public constructor() {
     this.form = new FormControl('');
@@ -47,6 +58,12 @@ export class AppComponent {
     this.sufixForm = new FormControl('');
     this.repeatForm = new FormControl('');
     this.separatorForm = new FormControl('');
+    this.dotSeparatorForm = new FormControl('');
+    this.dotPrecisionSeparatorForm = new FormControl('');
+    this.dotZeroPrecisionSeparatorForm = new FormControl('');
+    this.commaSeparatorForm = new FormControl('');
+    this.commaPrecisionSeparatorForm = new FormControl('');
+    this.commaZeroPrecisionSeparatorForm = new FormControl('');
     this.percent = new FormControl('');
 
     this.customMaska = ['PPP-PPP-PPP', this.pattern];

--- a/src/app/ngx-mask/test/separator.spec.ts
+++ b/src/app/ngx-mask/test/separator.spec.ts
@@ -57,4 +57,34 @@ describe('Separator: Mask', () => {
     equal('1000a', '1 000', fixture);
     equal('1000/', '1 000', fixture);
   });
+
+  it('dot_separator for 1000000', () => {
+    component.mask = 'dot_separator';
+    equal('1000000', '1.000.000', fixture);
+  });
+
+  it('dot_separator precision 2 for 1000000.00', () => {
+    component.mask = 'dot_separator.2';
+    equal('1000000,00', '1.000.000,00', fixture);
+  });
+
+  it('dot_separator precision 0 for 1000000.00', () => {
+    component.mask = 'dot_separator.0';
+    equal('1000000,00', '1.000.000', fixture);
+  });
+
+  it('coma_separator for 1000000', () => {
+    component.mask = 'coma_separator';
+    equal('1000000', '1,000,000', fixture);
+  });
+
+  it('coma_separator precision 2 for 1000000.00', () => {
+    component.mask = 'coma_separator.2';
+    equal('1000000.00', '1,000,000.00', fixture);
+  });
+
+  it('coma_separator precision 0 for 1000000.00', () => {
+    component.mask = 'coma_separator.0';
+    equal('1000000.00', '1,000,000', fixture);
+  });
 });


### PR DESCRIPTION
Was trying to use these masks for currency and the main issue I had was inability to have nice thousands formatting AND limiting the number of decimals input (in my case 0 or 2)

Added additional overrides to the existing masks to allow setting a precision on the input.
Added tests for the base dot_separator and coma_separator as well as my precision versions.
Updated samples on main page and readme.

Hope this is okay; was needed for work project so just had to do something; let me know if you'd prefer any alterations or change to this.

I also didn't increment the package version; I couldn't tell if it was desired for contributers to make that change so I left it alone, but you might want to make sure you update the version number in the package-lock.json and the ng-package.json if it's still in use as they're both rather out of date.