### PR TITLE
24h format mask example now uses minute not month

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Masked value: 1,234
 ##### Usage
 
 ```html
- <input type='text' mask="Hh:M0:s0">
+ <input type='text' mask="Hh:m0:s0">
 ```
 
 ### Percent validation


### PR DESCRIPTION
Just a simple fix for the 24h mask example in the documentation.