### PR TITLE
Cursor issues with backspace

### DIFF
--- a/src/app/ngx-mask/mask-applier.service.ts
+++ b/src/app/ngx-mask/mask-applier.service.ts
@@ -143,8 +143,8 @@ export class MaskApplierService {
                 } while (_shift < shiftStep);
             } else if (
                 commaShift !== 0 &&
-                result.indexOf(',') !== -1 &&
-                result.indexOf(',') < position &&
+                position > 0 &&
+                !(result.indexOf(',') >= position &&  position > 3) &&
                 shiftStep <= 0
             ) {
                 this._shift.clear();

--- a/src/app/ngx-mask/test/separator.spec.ts
+++ b/src/app/ngx-mask/test/separator.spec.ts
@@ -120,4 +120,38 @@ describe('Separator: Mask', () => {
         expect(inputTarget.value).toBe('123,467');
         expect(inputTarget.selectionStart).toEqual(5);
     });
+
+    it('sould not shift cursor on backspce when result has no separator', () => {
+        component.mask = 'comma_separator.0';
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        inputTarget.value = '1,34';
+        inputTarget.selectionStart = 2;
+        inputTarget.selectionEnd = 2;
+        debugElement.triggerEventHandler('keydown', { code: 'Backspace', keyCode: 8, target: inputTarget });
+        debugElement.triggerEventHandler('input', { target: inputTarget });
+
+        expect(inputTarget.value).toBe('134');
+        expect(inputTarget.selectionStart).toEqual(1);
+    });
+
+    it('should keep cursor on position 0 for backspce on first digit', () => {
+        component.mask = 'comma_separator.0';
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        inputTarget.value = ',134';
+        inputTarget.selectionStart = 0;
+        inputTarget.selectionEnd = 0;
+        debugElement.triggerEventHandler('keydown', { code: 'Backspace', keyCode: 8, target: inputTarget });
+        debugElement.triggerEventHandler('input', { target: inputTarget });
+
+        expect(inputTarget.value).toBe('134');
+        expect(inputTarget.selectionStart).toEqual(0);
+    });
 });


### PR DESCRIPTION
This fixes cursor backspace issues not solved by #396 
example:  deleting 2 with backspace on 1,2|34 resulted on 13|4 
Issue:  #436
