### PR TITLE
fix(mask-directive): replaced native KeyboardEvent with type alias

### DIFF
--- a/src/app/ngx-mask/custom-keyboard-event.ts
+++ b/src/app/ngx-mask/custom-keyboard-event.ts
@@ -1,0 +1,10 @@
+// tslint:disable: no-any typedef
+declare var global: any;
+
+(function() {
+    if (!global.KeyboardEvent) {
+        global.KeyboardEvent = function(_eventType: any, _init: any) {};
+    }
+})();
+
+export type CustomKeyboardEvent = KeyboardEvent;

--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -3,6 +3,7 @@ import { DOCUMENT } from '@angular/common';
 import { ControlValueAccessor, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors } from '@angular/forms';
 import { MaskService } from './mask.service';
 import { config, IConfig, withoutValidation } from './config';
+import { CustomKeyboardEvent } from './custom-keyboard-event';
 
 @Directive({
     selector: '[mask]',
@@ -180,7 +181,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
     }
 
     @HostListener('input', ['$event'])
-    public onInput(e: KeyboardEvent): void {
+    public onInput(e: CustomKeyboardEvent): void {
         const el: HTMLInputElement = e.target as HTMLInputElement;
         this._inputValue = el.value;
         if (!this._maskValue) {
@@ -218,7 +219,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
     }
 
     @HostListener('click', ['$event'])
-    public onFocus(e: MouseEvent | KeyboardEvent): void {
+    public onFocus(e: MouseEvent | CustomKeyboardEvent): void {
         const el: HTMLInputElement = e.target as HTMLInputElement;
         const posStart: number = 0;
         const posEnd: number = 0;
@@ -252,7 +253,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
     }
 
     @HostListener('keydown', ['$event'])
-    public a(e: KeyboardEvent): void {
+    public a(e: CustomKeyboardEvent): void {
         this._code = e.code;
         const el: HTMLInputElement = e.target as HTMLInputElement;
         this._maskService.selStart = el.selectionStart;


### PR DESCRIPTION
in order to avoid server errors we have to patch the global object with
fake implementation of the KeyboardEvent and add a type alias so that
the global object patch is executed right before the event reference in the code

fixes https://github.com/JsDaddy/ngx-mask/issues/399