### PR TITLE
Fix for #402: When mask is "comma_separator.2", Input with numeric ma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-mask",
-    "version": "7.9.1",
+    "version": "7.9.2",
     "description": "awesome ngx mask",
     "license": "MIT",
     "angular-cli": {},

--- a/src/app/ngx-mask/mask.service.ts
+++ b/src/app/ngx-mask/mask.service.ts
@@ -216,7 +216,9 @@ export class MaskService extends MaskApplierService {
     private _checkSymbols(result: string): string | number | undefined {
         if ('dot_separator.2' === this.maskExpression && this.isNumberValue) {
             // tslint:disable-next-line:max-line-length
-            return Number(
+            return result === ''
+                ? result
+                : Number(
                 this._removeMask(this._removeSufix(this._removePrefix(result)), this.maskSpecialCharacters).replace(
                     ',',
                     '.'
@@ -225,7 +227,9 @@ export class MaskService extends MaskApplierService {
         }
         if ('comma_separator.2' === this.maskExpression && this.isNumberValue) {
             // tslint:disable-next-line:max-line-length
-            return Number(
+            return result === ''
+                ? result
+                : Number(
                 this._removeMask(this._removeSufix(this._removePrefix(result)), this.maskSpecialCharacters)
             ).toFixed(2);
         }


### PR DESCRIPTION
…sk won't bind back correct value to model when value of field is blank

This is a fix for this issue, #420:

> Releated to Issue #380, when the user enters a numeric value matching the mask the component model is updated with that value, however when the user empties the input so that the value should be "" it is instead 0.00.
> 
> This bug was fixed in #380 but is still a problem when the mask is "comma_separator.2"
> 
> <input formControlName="TransportDollarsPerMile" class="form-control" id="transportDollarsPerMileId" type="text" placeholder="$" prefix="$" mask="comma_separator.2" />
> 
> When I clear out the input box, group.get('TransportDollarsPerMile') is 0.00. It should be null or "" so my angular required field validator can work.
> 

I haven't tested this locally since I wasn't able to get the dev environment up so be sure to test it!