### PR TITLE
fix(ngx-mask-module): added options factory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Import **ngx-mask** module in Angular app.
 ```typescript
 import {NgxMaskModule} from 'ngx-mask'
 
-(...)
+export const options: Partial<IConfig> | (() => Partial<IConfig>);
 
 @NgModule({
   (...)
@@ -82,13 +82,13 @@ Also you can use mask pipe
 
 #### Examples
 
-| mask | example |
-| ------- | ------- |
-| 9999-99-99 | 2017-04-15 |
-| 0*.00 | 2017.22 |
+| mask           | example        |
+| -------------- | -------------- |
+| 9999-99-99     | 2017-04-15     |
+| 0*.00          | 2017.22        |
 | 000.000.000-99 | 048.457.987-98 |
-| AAAA | 0F6g |
-| SSSS | asDF |
+| AAAA           | 0F6g           |
+| SSSS           | asDF           |
 
 ## Mask Options
 You can define your custom options for all directives (as  object in the mask module) or for each (as attributes for directive). If you override this parameter, you have to provide all the special characters (default one are not included).
@@ -125,12 +125,12 @@ patterns ({ [character: string]: { pattern: RegExp, optional?: boolean})
 ```
    We have next default patterns:
 
-  | code | meaning |
-  |------|---------|
-  | **0** | digits (like 0 to 9 numbers) |
-  | **9** | digits (like 0 to 9 numbers), but optional |
+  | code  | meaning                                     |
+  | ----- | ------------------------------------------- |
+  | **0** | digits (like 0 to 9 numbers)                |
+  | **9** | digits (like 0 to 9 numbers), but optional  |
   | **A** | letters (uppercase or lowercase) and digits |
-  | **S** | only letters (uppercase or lowercase) |
+  | **S** | only letters (uppercase or lowercase)       |
 
 ##### Usage:
 

--- a/src/app/ngx-mask/config.ts
+++ b/src/app/ngx-mask/config.ts
@@ -21,8 +21,8 @@ export interface IConfig {
 }
 
 export type optionsConfig = Partial<IConfig>;
-export const config: InjectionToken<string> = new InjectionToken('config');
-export const NEW_CONFIG: InjectionToken<string> = new InjectionToken('NEW_CONFIG');
+export const config: InjectionToken<IConfig> = new InjectionToken('config');
+export const NEW_CONFIG: InjectionToken<IConfig> = new InjectionToken('NEW_CONFIG');
 export const INITIAL_CONFIG: InjectionToken<IConfig> = new InjectionToken('INITIAL_CONFIG');
 
 export const initialConfig: IConfig = {

--- a/src/app/ngx-mask/ngx-mask.module.ts
+++ b/src/app/ngx-mask/ngx-mask.module.ts
@@ -1,9 +1,14 @@
-import { ModuleWithProviders, NgModule } from '@angular/core';
-
-import { config, INITIAL_CONFIG, initialConfig, NEW_CONFIG, optionsConfig } from './config';
+import {
+  config,
+  INITIAL_CONFIG,
+  initialConfig,
+  NEW_CONFIG,
+  optionsConfig
+  } from './config';
 import { MaskApplierService } from './mask-applier.service';
 import { MaskDirective } from './mask.directive';
 import { MaskPipe } from './mask.pipe';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 
 @NgModule({
     providers: [MaskApplierService],
@@ -11,7 +16,7 @@ import { MaskPipe } from './mask.pipe';
     declarations: [MaskDirective, MaskPipe],
 })
 export class NgxMaskModule {
-    public static forRoot(configValue?: optionsConfig): ModuleWithProviders {
+    public static forRoot(configValue?: optionsConfig | (() => optionsConfig)): ModuleWithProviders {
         return {
             ngModule: NgxMaskModule,
             providers: [
@@ -44,6 +49,6 @@ export class NgxMaskModule {
 export function _configFactory(
     initConfig: optionsConfig,
     configValue: optionsConfig | (() => optionsConfig)
-): Function | optionsConfig {
-    return typeof configValue === 'function' ? configValue() : { ...initConfig, ...configValue };
+): optionsConfig {
+    return configValue instanceof Function ? { ...initConfig, ...configValue() } : { ...initConfig, ...configValue };
 }


### PR DESCRIPTION
added factory support for options in `NgxMaskModule.forRoot(options)` in order to
allow customPatterns support at root level with aot complition

fixes issue: #290