### PR TITLE
[Resolves #495] Mask Directive - Allow cursor insertion in mid. of input

### DIFF
--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -248,10 +248,16 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
                     posStart;
                 }
             }
-        el.value =
+        const nextValue: string | null =
             !el.value || el.value === this._maskService.prefix
                 ? this._maskService.prefix + this._maskService.maskIsShown
                 : el.value;
+
+        /** Fix of cursor position jumping to end in most browsers no matter where cursor is inserted onFocus */
+        if (el.value !== nextValue) {
+            el.value = nextValue;
+        }
+
         /** fix of cursor position with prefix when mouse click occur */
         if (((el.selectionStart as number) || (el.selectionEnd as number)) <= this._maskService.prefix.length) {
             el.selectionStart = this._maskService.prefix.length;


### PR DESCRIPTION
Avoids overwriting input element's value onFocus when value has not changed. This fixes an issue in some browsers where the cursor would jump to the end of the input text no matter where the cursor was inserted.