### PR TITLE
Directive: remove selection block

### DIFF
--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -274,7 +274,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
         if (e.keyCode === 38) {
             e.preventDefault();
         }
-        if (e.keyCode === 8) {
+        if (e.keyCode === 37 || e.keyCode === 8) {
             if (e.keyCode === 8 && el.value.length === 0) {
                 el.selectionStart = el.selectionEnd;
             }

--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -274,10 +274,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
         if (e.keyCode === 38) {
             e.preventDefault();
         }
-        if (e.keyCode === 37 || e.keyCode === 8) {
-            if (e.keyCode === 37) {
-                el.selectionStart = (el.selectionEnd as number) - 1;
-            }
+        if (e.keyCode === 8) {
             if (e.keyCode === 8 && el.value.length === 0) {
                 el.selectionStart = el.selectionEnd;
             }


### PR DESCRIPTION
For the moment user can select 2 symbols max (for example using shift+arrow left). Removing fixes the problem. Also haven't found any suited use case for this lines