### PR TITLE
Fix readonly input's model being emptied

### DIFF
--- a/src/app/ngx-mask/mask.directive.ts
+++ b/src/app/ngx-mask/mask.directive.ts
@@ -208,8 +208,8 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
             this._position !== null
                 ? this._position
                 : position +
-                  // tslint:disable-next-line
-                  (this._code === 'Backspace' && !backspaceShift ? 0 : caretShift);
+                // tslint:disable-next-line
+                (this._code === 'Backspace' && !backspaceShift ? 0 : caretShift);
         this._position = null;
     }
 
@@ -289,7 +289,8 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
             }
             const cursorStart: number | null = el.selectionStart;
             // this.onFocus(e);
-            if (e.keyCode === 8 && cursorStart === 0 && el.selectionEnd === el.value.length && el.value.length !== 0) {
+            if (e.keyCode === 8 && !el.readOnly &&
+                cursorStart === 0 && el.selectionEnd === el.value.length && el.value.length !== 0) {
                 this._position = this._maskService.prefix ? this._maskService.prefix.length : 0;
                 this._maskService.applyMask(this._maskService.prefix, this._maskService.maskExpression, this._position);
             }
@@ -312,11 +313,11 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
             this._maskService.isNumberValue = true;
         }
         (inputValue && this._maskService.maskExpression) ||
-        (this._maskService.maskExpression && (this._maskService.prefix || this._maskService.showMaskTyped))
+            (this._maskService.maskExpression && (this._maskService.prefix || this._maskService.showMaskTyped))
             ? (this._maskService.formElementProperty = [
-                  'value',
-                  this._maskService.applyMask(inputValue, this._maskService.maskExpression),
-              ])
+                'value',
+                this._maskService.applyMask(inputValue, this._maskService.maskExpression),
+            ])
             : (this._maskService.formElementProperty = ['value', inputValue]);
         this._inputValue = inputValue;
     }

--- a/src/app/ngx-mask/test/basic-logic.spec.ts
+++ b/src/app/ngx-mask/test/basic-logic.spec.ts
@@ -3,6 +3,9 @@ import { NgxMaskModule } from '../ngx-mask.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TestMaskComponent } from './utils/test-component.component';
 import { equal, typeTest } from './utils/test-functions.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { MaskDirective } from '..';
 
 describe('Directive: Mask', () => {
     let fixture: ComponentFixture<TestMaskComponent>;
@@ -234,5 +237,41 @@ describe('Directive: Mask', () => {
     it('should be bank card number', () => {
         component.mask = '0000-0000-0000-0000';
         equal('1234567890123456', '1234-5678-9012-3456', fixture);
+    });
+
+    it('sould apply mask on backspace for readonly inputs when all text is selected', () => {
+        component.mask = 'AAAAAA';
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        inputTarget.value = 'abcdef';
+        inputTarget.readOnly = false;
+        inputTarget.selectionStart = 0;
+        inputTarget.selectionEnd = 6;
+
+        const directiveInstance: MaskDirective = debugElement.injector.get(MaskDirective);
+        spyOn(directiveInstance['_maskService'], 'applyMask');
+        debugElement.triggerEventHandler('keydown', { code: 'Backspace', keyCode: 8, target: inputTarget });
+        expect(directiveInstance['_maskService'].applyMask).toHaveBeenCalled();
+    });
+
+    it('should not apply mask on backspace for readonly inputs when all text is selected', () => {
+        component.mask = 'AAAAAA';
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        inputTarget.value = 'abcdef';
+        inputTarget.readOnly = true;
+        inputTarget.selectionStart = 0;
+        inputTarget.selectionEnd = 6;
+
+        const directiveInstance: MaskDirective = debugElement.injector.get(MaskDirective);
+        spyOn(directiveInstance['_maskService'], 'applyMask');
+        debugElement.triggerEventHandler('keydown', { code: 'Backspace', keyCode: 8, target: inputTarget });
+        expect(directiveInstance['_maskService'].applyMask).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Fix readonly input's model being emptied on backspace when all text is selected.

You can test the fix by modifying your demo app :
- In `app.component.html`, add `readonly` to any input.
    - Example for the first date format input : `<input matInput placeholder="Date" readonly  mask="00/00/0000"  [(ngModel)]="formModelDate" 
                      [formControl]="formDate">`
- In `app.component.ts`, set a default value to the property matching the above input's `ngModel`
    - Example for the date format input's model : `public formModelDate: SN = '12345678';`
- Launch the app
- Select all text in the modified input and press backspace.
- Result : 
   - In the current version, the value will stay displayed in the input, but the ngModel and the FormControl values will be emptied.
    - In the PR version, the value is still displayed in the input and the ngModel and FormControl values do not change.