### PR TITLE
Allowed support for decimal values below 1000, eg. 1.1

### DIFF
--- a/src/app/ngx-mask/mask-applier.service.ts
+++ b/src/app/ngx-mask/mask-applier.service.ts
@@ -106,7 +106,7 @@ export class MaskApplierService {
                 if (
                     inputValue.indexOf('.') !== -1 &&
                     inputValue.indexOf('.') === inputValue.lastIndexOf('.') &&
-                    inputValue.indexOf('.') > 3
+                    (inputValue.indexOf('.') > 3  || inputValue.length < 6)
                 ) {
                     inputValue = inputValue.replace('.', ',');
                 }


### PR DESCRIPTION
An easy fix to resolve an issue with piping a number like 1.1 returns 11. 