### PR TITLE
Add feature to allow negative numbers in separator masked inputs

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -406,7 +406,9 @@ export class MaskApplierService {
   private _stripToDecimal(str: string): string {
     return str
       .split('')
-      .filter((i: string) => i.match('\\d') || i === '.' || i === ',')
+      .filter((i: string, idx: number) => {
+        return i.match('^-?\\d') || i === '.' || i === ',' || (i === '-' && idx == 0)
+      })
       .join('');
   }
 

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -358,10 +358,11 @@ export class MaskApplierService {
     let res: string = x[0];
     const separatorLimit: string = this.separatorLimit.replace(/\s/g, '');
     if (separatorLimit && +separatorLimit) {
-      if(res[0] === '-')
-        res = `-${res.slice(1, res.length).slice(0, separatorLimit.length)}`;
-      else
-        res = res.slice(0, separatorLimit.length);
+      if (res[0] === '-') {
+          res = `-${res.slice(1, res.length).slice(0, separatorLimit.length)}`;
+      } else {
+          res = res.slice(0, separatorLimit.length);
+      }
     }
     const rgx: RegExp = /(\d+)(\d{3})/;
     while (rgx.test(res)) {
@@ -410,7 +411,7 @@ export class MaskApplierService {
     return str
       .split('')
       .filter((i: string, idx: number) => {
-        return i.match('^-?\\d') || i === '.' || i === ',' || (i === '-' && idx == 0)
+        return i.match('^-?\\d') || i === '.' || i === ',' || (i === '-' && idx === 0);
       })
       .join('');
   }

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -358,7 +358,10 @@ export class MaskApplierService {
     let res: string = x[0];
     const separatorLimit: string = this.separatorLimit.replace(/\s/g, '');
     if (separatorLimit && +separatorLimit) {
-      res = res.slice(0, separatorLimit.length);
+      if(res[0] === '-')
+        res = `-${res.slice(1, res.length).slice(0, separatorLimit.length)}`;
+      else
+        res = res.slice(0, separatorLimit.length);
     }
     const rgx: RegExp = /(\d+)(\d{3})/;
     while (rgx.test(res)) {

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -135,6 +135,18 @@ describe('Separator: Mask', () => {
     equal('1000000', '1.000.000', fixture);
   });
 
+  it('should not accept more than one minus signal at the beginning of input for separator thousandSeparator . for --1000', () => {
+    component.mask = 'separator';
+    component.thousandSeparator = '.';
+    equal('--1000', '-1.000', fixture);
+  });
+
+  it('should not accept more than one minus signal for separator thousandSeparator . for -100-0000', () => {
+    component.mask = 'separator';
+    component.thousandSeparator = '.';
+    equal('-100-0000', '-1.000.000', fixture);
+  });
+
   it('should limit separator thousandSeparator . to 100000', () => {
     component.mask = 'separator';
     component.thousandSeparator = '.';

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -31,14 +31,34 @@ describe('Separator: Mask', () => {
     equal('100', '100', fixture);
   });
 
+  it('separator for -100', () => {
+    component.mask = 'separator';
+    equal('-100', '-100', fixture);
+  });
+
   it('separator for 1000', () => {
     component.mask = 'separator';
     equal('1000', '1 000', fixture);
   });
 
+  it('separator for -1000', () => {
+    component.mask = 'separator';
+    equal('-1000', '-1 000', fixture);
+  });
+
   it('separator for 10000', () => {
     component.mask = 'separator';
     equal('10000', '10 000', fixture);
+  });
+
+  it('separator for -10000', () => {
+    component.mask = 'separator';
+    equal('-10000', '-10 000', fixture);
+  });
+
+  it('separator for -100000', () => {
+    component.mask = 'separator';
+    equal('-100000', '-100 000', fixture);
   });
 
   it('separator for 100000', () => {
@@ -51,6 +71,11 @@ describe('Separator: Mask', () => {
     equal('1000000', '1 000 000', fixture);
   });
 
+  it('separator for -1000000', () => {
+    component.mask = 'separator';
+    equal('-1000000', '-1 000 000', fixture);
+  });
+
   it('should limit separator to 1000', () => {
     component.mask = 'separator';
     component.separatorLimit = '1000';
@@ -60,6 +85,11 @@ describe('Separator: Mask', () => {
   it('separator precision 2 for 1000000.00', () => {
     component.mask = 'separator.2';
     equal('1000000.00', '1 000 000.00', fixture);
+  });
+
+  it('separator precision 2 for -1000000.00', () => {
+    component.mask = 'separator.2';
+    equal('-1000000.00', '-1 000 000.00', fixture);
   });
 
   it('should limit separator with precision 2 to 10000', () => {
@@ -112,10 +142,23 @@ describe('Separator: Mask', () => {
     equal('1000000', '100.000', fixture);
   });
 
+  it('should limit separator thousandSeparator . to -100000', () => {
+    component.mask = 'separator';
+    component.thousandSeparator = '.';
+    component.separatorLimit = '100000';
+    equal('-1000000', '-100.000', fixture);
+  });
+
   it('separator thousandSeparator . precision 2 for 1000000.00', () => {
     component.mask = 'separator.2';
     component.thousandSeparator = '.';
     equal('1000000,00', '1.000.000,00', fixture);
+  });
+
+  it('separator thousandSeparator . precision 2 for -1000000.00', () => {
+    component.mask = 'separator.2';
+    component.thousandSeparator = '.';
+    equal('-1000000,00', '-1.000.000,00', fixture);
   });
 
   it('separator thousandSeparator . precision 2 with 0 after point for 1000000.00', () => {


### PR DESCRIPTION
Based in issues from the community, it was made an enhancement in the main source code to add the feature which permits the end user to type negative values in fields configured with separator mask.

The main change was made in `_stripToDecimal` method as follows, which originally stripped all characters which were no digits. Now it keeps only one hyphen (minus signal) at the first character.

```javascript
private _stripToDecimal(str: string): string {
    return str
      .split('')
      .filter((i: string, idx: number) => {
        return i.match('^-?\\d') || i === '.' || i === ',' || (i === '-' && idx == 0)
      })
      .join('');
  }
```

There were changes made to `separatorLimit` logic also, so that initial hyphen doesn't interfere on digit amount limiting.