### PR TITLE
Added import and clarified general usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm install --save ngx-mask
 Import **ngx-mask** module in Angular app.
 
 ```typescript
-import { NgxMaskModule } from 'ngx-mask'
+import { NgxMaskModule, IConfig } from 'ngx-mask'
 
 export const options: Partial<IConfig> | (() => Partial<IConfig>);
 
@@ -48,7 +48,11 @@ Then, just define masks in inputs.
 ### Usage
 
 ```html
-<input type="text" mask="{here comes your mask}" />
+<input type="text" mask="<here goes your mask>" />
+```
+or
+```html
+<input type="text" [mask]="<here goes a reference to your component's mask property>" />
 ```
 
 Also, you can use mask pipe.


### PR DESCRIPTION
`IConfig` was missing from the simple example.
The first example should also include how to use it with a component/view-model property, not just a string literal.