### PR TITLE
Curly brace do not go around mask for inline mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, just define masks in inputs.
 ### Usage
 
 ```html
-<input type="text" mask="{here comes your mask}" />
+<input type="text" mask="here comes your mask" />
 ```
 
 Also, you can use mask pipe.


### PR DESCRIPTION
Should solve some new user issues of copy pasting the example.

IE: This works mask="00/00/0000" but this will not work mask="{00/00/0000}"