### PR TITLE
feat: #381 Allow negative numbers to be used and properly formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,23 @@ You can choose if mask is shown while typing, or not, default value is `false`.
  <input mask="(000) 000-0000" prefix="+7" [showMaskTyped]="true" />
 ```
 
+### allowNegativeNumbers (boolean)
+
+You can choose if mask will allow the use of negative numbers. The default value is `false`.
+
+#### Usage
+
+```html
+<input type="text" [allowNegativeNumbers]="true" mask="separator.2" />
+```
+
+##### Then
+
+```text
+Input value: -10,000.45
+Model value: -10000.45
+```
+
 ### placeHolderCharacter (string)
 
 If the `showMaskTyped` parameter is enabled, this setting customizes the character used as placeholder. Default value is `_`.

--- a/projects/ngx-mask-lib/src/lib/config.ts
+++ b/projects/ngx-mask-lib/src/lib/config.ts
@@ -15,6 +15,7 @@ export interface IConfig {
   hiddenInput: boolean | undefined;
   validation: boolean;
   separatorLimit: string;
+  allowNegativeNumbers: boolean;
   patterns: {
     [character: string]: {
       pattern: RegExp;
@@ -42,6 +43,7 @@ export const initialConfig: IConfig = {
   hiddenInput: undefined,
   shownMaskExpression: '',
   separatorLimit: '',
+  allowNegativeNumbers: false,
   validation: true,
   // tslint:disable-next-line: quotemark
   specialCharacters: ['-', '/', '(', ')', '.', ':', ' ', '+', ',', '@', '[', ']', '"', "'"],

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -23,6 +23,7 @@ export class MaskApplierService {
   public placeHolderCharacter!: IConfig['placeHolderCharacter'];
   public validation: IConfig['validation'];
   public separatorLimit: IConfig['separatorLimit'];
+  public allowNegativeNumbers: IConfig['allowNegativeNumbers'];
 
   private _shift!: Set<number>;
 
@@ -41,6 +42,7 @@ export class MaskApplierService {
     this.placeHolderCharacter = this._config.placeHolderCharacter;
     this.validation = this._config.validation;
     this.separatorLimit = this._config.separatorLimit;
+    this.allowNegativeNumbers = this._config.allowNegativeNumbers;
   }
 
   public applyMaskWithPattern(inputValue: string, maskAndPattern: [string, IConfig['patterns']]): string {

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -40,6 +40,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
   @Input() public clearIfNotMatch: IConfig['clearIfNotMatch'] | null = null;
   @Input() public validation: IConfig['validation'] | null = null;
   @Input() public separatorLimit: IConfig['separatorLimit'] | null = null;
+  @Input() public allowNegativeNumbers: IConfig['allowNegativeNumbers'] | null = null;
   private _maskValue: string = '';
   private _inputValue!: string;
   private _position: number | null = null;
@@ -74,6 +75,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
       clearIfNotMatch,
       validation,
       separatorLimit,
+      allowNegativeNumbers,
     } = changes;
     if (maskExpression) {
       this._maskValue = changes.maskExpression.currentValue || '';
@@ -127,6 +129,9 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
     }
     if (separatorLimit) {
       this._maskService.separatorLimit = separatorLimit.currentValue;
+    }
+    if (allowNegativeNumbers) {
+      this._maskService.maskSpecialCharacters = this._maskService.maskSpecialCharacters.filter((c: string) => c !== '-');
     }
     this._applyMask();
   }

--- a/projects/ngx-mask-lib/src/test/allow-negative-numbers.spec.ts
+++ b/projects/ngx-mask-lib/src/test/allow-negative-numbers.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { NgxMaskModule } from '../lib/ngx-mask.module';
+import { TestMaskComponent } from './utils/test-component.component';
+import { equal } from './utils/test-functions.component';
+
+describe('Directive: Mask (Allow negative numbers)', () => {
+  let fixture: ComponentFixture<TestMaskComponent>;
+  let component: TestMaskComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestMaskComponent],
+      imports: [ReactiveFormsModule, NgxMaskModule.forRoot()],
+    });
+    fixture = TestBed.createComponent(TestMaskComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('FormControl or NgModel should not allow negative numbers (default functionality)', () => {
+    component.mask = 'separator.2';
+    component.thousandSeparator = ',';
+    component.allowNegativeNumbers = false;
+    component.dropSpecialCharacters = true;
+    equal('-10,000.00', '-10,000.00', fixture);
+
+    expect(component.form.value).toBe('10000.00');
+    expect(component.ngModelValue).toBe('10000.00');
+
+    component.form.setValue(-123456);
+    equal('-123456.00', '-123,456.00', fixture);
+    expect(component.form.value).toBe('123456.00');
+    expect(component.ngModelValue).toBe('123456.00');
+  });
+
+  it('FormControl and NgModel should be filled with negative values', () => {
+    component.mask = 'separator.2';
+    component.thousandSeparator = ',';
+    component.allowNegativeNumbers = true;
+    component.dropSpecialCharacters = true;
+    component.form.setValue(-123456);
+
+    equal('-123456.00', '-123,456.00', fixture);
+    expect(component.form.value).toBe('-123456.00');
+    expect(component.ngModelValue).toBe('-123456.00');
+  });
+});

--- a/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
@@ -22,6 +22,7 @@ import { IConfig } from '../../lib/config';
       [placeHolderCharacter]="placeHolderCharacter"
       [separatorLimit]="separatorLimit"
       [hiddenInput]="hiddenInput"
+      [allowNegativeNumbers]="allowNegativeNumbers"
       [(ngModel)]="ngModelValue"
     />
   `,
@@ -42,4 +43,5 @@ export class TestMaskComponent {
   public placeHolderCharacter: IConfig['placeHolderCharacter'] = '_';
   public hiddenInput: IConfig['hiddenInput'] = false;
   public separatorLimit: IConfig['separatorLimit'] = '';
+  public allowNegativeNumbers: IConfig['allowNegativeNumbers'] = false;
 }


### PR DESCRIPTION
Negative numbers are not correctly handled by the library, for instance if the input has the value `-123,456.45` the model would have the value of `123456.45` if  `dropSpecialCharacters` is set to `true`. If `dropSpecialCharacters` is set to `false` then the model would have the value of `-123,456.45` which then needs to be stripped of the comma for real world use so this change fixes that.

If you set `allowNegativeNumbers` to `true` and the input has the value of `-123,456.45`, then the model would have the correct value of `-123456.45`.