### PR TITLE
Update mask.directive.ts to resolve sufix and suffix miss match

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -28,7 +28,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges {
   @Input() public specialCharacters: IConfig['specialCharacters'] = [];
   @Input() public patterns: IConfig['patterns'] = {};
   @Input() public prefix: IConfig['prefix'] = '';
-  @Input() public suffix: IConfig['suffix'] = '';
+  @Input('sufix') public suffix: IConfig['suffix'] = '';
   @Input() public thousandSeparator: IConfig['thousandSeparator'] = ' ';
   @Input() public decimalMarker: IConfig['decimalMarker'] = '.';
   @Input() public dropSpecialCharacters: IConfig['dropSpecialCharacters'] | null = null;


### PR DESCRIPTION
We have two different libraries, one lib using older version and one is using new version. Those are not comfortable each other. When you made change to input variables still you have to carry forward the old variable name. Please approve this request. 