### PR TITLE
refactor(directive): change directive selector to input[mask]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="9.1.0">
+
+# [9.1.0 Directive's selector change](2020-05-20)
+
+Change directive selector to restrict to input and textarea tags
+
 <a name="9.0.2">
 
 # [9.0.2 Bugfix](2020-04-20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "description": "awesome ngx mask",
   "license": "MIT",
   "angular-cli": {},

--- a/projects/ngx-mask-lib/package.json
+++ b/projects/ngx-mask-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "description": "awesome ngx mask",
   "keywords": [
     "ng2-mask",

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -15,7 +15,7 @@ import { MaskService } from './mask.service';
 
 // tslint:disable deprecation
 @Directive({
-  selector: '[mask]',
+  selector: 'input[mask]',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -14,6 +14,7 @@ import { config, IConfig, timeMasks, withoutValidation } from './config';
 import { MaskService } from './mask.service';
 
 // tslint:disable deprecation
+// tslint:disable no-input-rename
 @Directive({
   selector: 'input[mask]',
   providers: [

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -16,7 +16,7 @@ import { MaskService } from './mask.service';
 // tslint:disable deprecation
 // tslint:disable no-input-rename
 @Directive({
-  selector: 'input[mask]',
+  selector: 'input[mask], textarea[mask]',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
Implement issue #738 

It might cause a breaking change if some use the directive on other elements than an `input` (ex: textarea like user in issue #493)