### PR TITLE
Options variable in app.module.ts is not initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Import **ngx-mask** module in Angular app.
 ```typescript
 import { NgxMaskModule, IConfig } from 'ngx-mask'
 
-export const options: Partial<IConfig> | (() => Partial<IConfig>);
+export const options: Partial<IConfig> | (() => Partial<IConfig>) = null;
 
 @NgModule({
   imports: [


### PR DESCRIPTION
Hi there!

I got an error saying that `const declarations must be initialized`. It should be simply repaired by initializing it to null. I updated the `README.md` page.