### PR TITLE
fix(mask-applier.service) The hiddenInput no longer allows asterisk

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -189,12 +189,7 @@ export class MaskApplierService {
         ) {
           result += inputSymbol;
           cursor += 3;
-        } else if (
-          this._checkSymbolMask(inputSymbol, maskExpression[cursor]) ||
-          (this.hiddenInput &&
-            this.maskAvailablePatterns[maskExpression[cursor]] &&
-            this.maskAvailablePatterns[maskExpression[cursor]].symbol === inputSymbol)
-        ) {
+        } else if (this._checkSymbolMask(inputSymbol, maskExpression[cursor])) {
           if (maskExpression[cursor] === 'H') {
             if (Number(inputSymbol) > 2) {
               cursor += 1;


### PR DESCRIPTION
fix #635 
Removed hiddenInput and inputSymbol check. I'm not sure what it doing besides allowing '*'.