### PR TITLE
fix: #646 Special characters in optional numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "11.1.3",
+  "version": "11.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -322,14 +322,6 @@ export class MaskApplierService {
           this.maskAvailablePatterns[maskExpression[cursor]] &&
           this.maskAvailablePatterns[maskExpression[cursor]].optional
         ) {
-          if (
-            !!inputArray[cursor] &&
-            maskExpression !== '099.099.099.099' &&
-            maskExpression !== '000.000.000-00' &&
-            maskExpression !== '00.000.000/0000-00'
-          ) {
-            result += inputArray[cursor];
-          }
           cursor++;
           i--;
         } else if (

--- a/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
@@ -125,6 +125,13 @@ describe('Directive: Mask', () => {
     equal('(123) 456-ABCD1', '(123) 456-ABCD', fixture);
   });
 
+  it('Masks with optional numbers', () => {
+    component.mask = '99999';
+    equal('1', '1', fixture);
+    equal('112', '112', fixture);
+    equal('123456', '12345', fixture);
+  });
+
   it('Masks with ip', () => {
     component.mask = '099.099.099.099';
     equal('1.1.1.1', '1.1.1.1', fixture);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A mask containing only 9's allows to input special characters such as slashes, quotation marks, brackets etc. and from there on allows to input characters too.

Issue Number: 646

## What is the new behavior?

The digit only mask (9) prevent the input of special characters.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
