### PR TITLE
fix: #763 Dynamic mask initializes with wrong value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "11.1.3",
+  "version": "11.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -440,6 +440,10 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
       inputValue = this.decimalMarker !== '.' ? inputValue.replace('.', this.decimalMarker) : inputValue;
       this._maskService.isNumberValue = true;
     }
+
+    this._inputValue = inputValue;
+    this._setMask();
+
     if (
       (inputValue && this._maskService.maskExpression) ||
       (this._maskService.maskExpression && (this._maskService.prefix || this._maskService.showMaskTyped))

--- a/projects/ngx-mask-lib/src/test/dynamic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/dynamic.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { NgxMaskModule } from '../lib/ngx-mask.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TestMaskComponent } from './utils/test-component.component';
+
+describe('Directive: Mask (Dynamic)', () => {
+  let fixture: ComponentFixture<TestMaskComponent>;
+  let component: TestMaskComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestMaskComponent],
+      imports: [ReactiveFormsModule, NgxMaskModule.forRoot()],
+    });
+    fixture = TestBed.createComponent(TestMaskComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('The input value when set by the FormControl should be masked accordingly the dynamic mask', async () => {
+    component.mask = '000-0||0000-0||00000-0';
+    fixture.detectChanges();
+
+    component.form.setValue({
+      value: 1234,
+    });
+    fixture.detectChanges();
+    let inputEl = fixture.debugElement.query(By.css('input'));
+    Promise.resolve().then(() => {
+      expect(inputEl.nativeElement.value).toEqual('123-4');
+    });
+
+    component.form.setValue({
+      value: 12345,
+    });
+    fixture.detectChanges();
+    inputEl = fixture.debugElement.query(By.css('input'));
+    Promise.resolve().then(() => {
+      expect(inputEl.nativeElement.value).toEqual('1234-5');
+    });
+
+    component.form.setValue({
+      value: 123456,
+    });
+    fixture.detectChanges();
+    inputEl = fixture.debugElement.query(By.css('input'));
+    Promise.resolve().then(() => {
+      expect(inputEl.nativeElement.value).toEqual('12345-6');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/JsDaddy/ngx-mask/issues/763

## What is the new behavior?

The input value when set by the FormControl is masked accordingly with the dynamic mask

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
