### PR TITLE
fix(#909): Fixed issue where active elements within a shadowRoot would not be found by mask.

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -273,7 +273,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
       }
     );
     // only set the selection if the element is active
-    if (this.document.activeElement !== el) {
+    if (this._getActiveElement() !== el) {
       return;
     }
     this._position = this._position === 1 && this._inputValue.length === 1 ? null : this._position;
@@ -569,6 +569,17 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
           this._maskService.maskExpression = this._maskExpressionArray[this._maskExpressionArray.length - 1];
         }
       });
+    }
+  }
+  /**
+   * Recursively determine the current active element by navigating the Shadow DOM until the Active Element is found.
+   */
+  private _getActiveElement(document: DocumentOrShadowRoot = this.document): Element | null {
+    const shadowRootEl = document?.activeElement?.shadowRoot;
+    if (!shadowRootEl?.activeElement) {
+      return document.activeElement;
+    } else {
+      return this._getActiveElement(shadowRootEl);
     }
   }
 }

--- a/projects/ngx-mask-lib/src/lib/mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.service.ts
@@ -131,7 +131,7 @@ export class MaskService extends MaskApplierService {
   ): void {
     const formElement = this._elementRef.nativeElement;
     formElement.value = this.applyMask(formElement.value, this.maskExpression, position, justPasted, backspaced, cb);
-    if (formElement === this.document.activeElement) {
+    if (formElement === this._getActiveElement()) {
       return;
     }
     this.clearIfNotMatchFn();
@@ -407,4 +407,16 @@ export class MaskService extends MaskApplierService {
     }
     return Number(separatorValue);
   }
+
+    /**
+   * Recursively determine the current active element by navigating the Shadow DOM until the Active Element is found.
+   */
+     private _getActiveElement(document: DocumentOrShadowRoot = this.document): Element | null {
+      const shadowRootEl = document?.activeElement?.shadowRoot;
+      if (!shadowRootEl?.activeElement) {
+        return document.activeElement;
+      } else {
+        return this._getActiveElement(shadowRootEl);
+      }
+    }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,9 +20,10 @@ import { AppRoutingModule } from './app.routes';
 import { BugsComponent } from './bugs/bugs.component';
 import { ShowcaseComponent } from './showcase/showcase.component';
 import { ErrorComponent } from './error/error.component';
+import { ShadowDomComponent } from './bugs/shadow-dom/shadow-dom.component';
 
 @NgModule({
-  declarations: [AppComponent, BugsComponent, ErrorComponent, ShowcaseComponent, TestMaskComponent],
+  declarations: [AppComponent, BugsComponent, ErrorComponent, ShowcaseComponent, TestMaskComponent, ShadowDomComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,

--- a/src/app/bugs/bugs.component.html
+++ b/src/app/bugs/bugs.component.html
@@ -165,6 +165,10 @@
   </div>
 
   <div class="container box">
+    <app-shadow-dom></app-shadow-dom>
+  </div>
+
+  <div class="container box">
     <div class="row">
       <div class="col-12">
         <button type="submit" mat-raised-button color="primary">Submit</button>
@@ -187,4 +191,7 @@
       </div>
     </div>
   </div>
+
+
+
 </form>

--- a/src/app/bugs/bugs.component.ts
+++ b/src/app/bugs/bugs.component.ts
@@ -24,7 +24,7 @@ export class BugsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.onDestroy$.next();
+    this.onDestroy$.next(null);
     this.onDestroy$.complete();
   }
 

--- a/src/app/bugs/shadow-dom/shadow-dom.component.html
+++ b/src/app/bugs/shadow-dom/shadow-dom.component.html
@@ -1,0 +1,37 @@
+
+<div class="row">
+  <div class="col-12">
+    <label for="ShadowDomMaskTyped">Input Field for ViewEncapsulation.ShadowDom with showMaskTyped=true</label>
+    <div>
+      <p>
+        <input
+          type="text"
+          placeholder="Phone Number"
+          mask="(000) 000-0000"
+          formControlName="ShadowDomMaskTyped"
+          id="ShadowDomMaskTyped"
+          [showMaskTyped]="true"
+        />
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-12">
+    <label for="ShadowDom">Input Field for ViewEncapsulation.ShadowDom with showMaskTyped=false</label>
+    <div>
+      <p>
+        <input
+          type="text"
+          placeholder="Phone Number"
+          mask="(000) 000-0000"
+          formControlName="ShadowDom"
+          id="ShadowDom"
+          [showMaskTyped]="false"
+        />
+      </p>
+    </div>
+  </div>
+</div>
+

--- a/src/app/bugs/shadow-dom/shadow-dom.component.ts
+++ b/src/app/bugs/shadow-dom/shadow-dom.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-shadow-dom',
+  templateUrl: './shadow-dom.component.html',
+  styleUrls: ['./shadow-dom.component.scss'],
+  encapsulation: ViewEncapsulation.ShadowDom
+})
+export class ShadowDomComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
Fixed an issue where active elements within a shadowRoot would not found by the mask service or directive, causing backspace to be handled improperly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) - I do not believe sending a backspace keystroke to an input can be properly tested with Karma/Jasmine, no new unit tests has been added. Instead, an interactable component has been added to the bugs page.
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Mask directive and service use document.activeElement to determine the active input element, which does not account for active elements within a Shadow DOM

Issue Number: #909 

## What is the new behavior?
Mask directive and service use new method to recursively determine the activeElement of shadowRoots. If no shadowRoot is found for the the document's active element, the directive and service continues to behave as before.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
