### PR TITLE
fix: #922 Scientific notation format

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -515,7 +515,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 
 		if (typeof inputValue === 'number') {
 			// eslint-disable-next-line no-param-reassign
-			inputValue = String(inputValue);
+      inputValue = this._maskService.numberToString(inputValue);
 			// eslint-disable-next-line no-param-reassign
 			inputValue =
 				this.decimalMarker !== '.' ? inputValue.replace('.', this.decimalMarker) : inputValue;

--- a/projects/ngx-mask-lib/src/lib/mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.service.ts
@@ -220,6 +220,18 @@ export class MaskService extends MaskApplierService {
 		return newInputValue.join('');
 	}
 
+  /**
+   * Convert number value to string
+   * 3.1415 -> '3.1415'
+   * 1e-7 -> '0.0000001'
+   */
+  public numberToString(value: number | string): string {
+    if (!value && value !== 0) {
+      return String(value);
+    }
+    return Number(value).toLocaleString('fullwide', { useGrouping: false, maximumFractionDigits: 20 })
+  }
+
 	public showMaskInInput(inputVal?: string): string {
 		if (this.showMaskTyped && !!this.shownMaskExpression) {
 			if (this.maskExpression.length !== this.shownMaskExpression.length) {

--- a/src/app/bugs/bugs.component.html
+++ b/src/app/bugs/bugs.component.html
@@ -165,6 +165,31 @@
   <div class="container box">
     <div class="row">
       <div class="col-12">
+        <label for="ScientificNotation">Correctly display numbers in scientific notation, e.g. 5e-7</label>
+        <div>
+          <p>
+            <input
+              type="text"
+              mask="separator.7"
+              thousandSeparator=" "
+              decimalMarker=","
+              formControlName="ScientificNotation"
+              id="ScientificNotation"
+            />
+          </p>
+          <p>
+            Valid: {{ bugsForm.controls.ScientificNotation.valid }}<br />
+            Value: {{ bugsForm.controls.ScientificNotation.value }}<br />
+            Errors: {{ bugsForm.controls.ScientificNotation.errors | json }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container box">
+    <div class="row">
+      <div class="col-12">
         <button type="submit" mat-raised-button color="primary">Submit</button>
         <button type="reset" mat-raised-button color="accent">Native Reset</button>
         <button type="button" mat-raised-button color="accent" (click)="resetForm()">Angular Reset</button>

--- a/src/app/bugs/bugs.component.ts
+++ b/src/app/bugs/bugs.component.ts
@@ -24,6 +24,7 @@ export class BugsComponent implements OnInit, OnDestroy {
 			DecMarkerDot: [],
 			CorrectRemovingSpace: [1200300.99],
 			SecureInput: [987654321],
+      ScientificNotation: [0.0000005],
 		});
 	}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #922

## What is the new behavior?

Scientific notation numbers are being handled as expected
e.g. `4e-7` is displayed as `0.0000004`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
