### PR TITLE
fix(mask.directive.ts): _maskExpressionArray does not clear after change mask from several to one

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -129,7 +129,6 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 			) {
 				this._maskService.maskChanged = true;
 			}
-			this._maskValue = maskExpression.currentValue || '';
 			if (maskExpression.currentValue && maskExpression.currentValue.split('||').length > 1) {
 				this._maskExpressionArray = maskExpression.currentValue
 					.split('||')
@@ -139,6 +138,10 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 				this._maskValue = this._maskExpressionArray[0]!;
 				this.maskExpression = this._maskExpressionArray[0]!;
 				this._maskService.maskExpression = this._maskExpressionArray[0]!;
+			} else {
+				this._maskExpressionArray = [];
+				this._maskValue = maskExpression.currentValue || '';
+				this._maskService.maskExpression = this._maskValue;
 			}
 		}
 		if (specialCharacters) {

--- a/projects/ngx-mask-lib/src/test/dynamic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/dynamic.spec.ts
@@ -50,4 +50,48 @@ describe('Directive: Mask (Dynamic)', () => {
 			expect(inputEl.nativeElement.value).toEqual('12345-6');
 		});
 	});
+
+	it('Change mask dynamically from mask several masks to one', async () => {
+		component.mask = '(000)0000-000||(000)0000-0000||00-00000-00000'; // China phone formats
+		fixture.detectChanges();
+
+		component.form.setValue({
+			value: 1234567890,
+		});
+		fixture.detectChanges();
+		let inputEl = fixture.debugElement.query(By.css('input'));
+		Promise.resolve().then(() => {
+			expect(inputEl.nativeElement.value).toEqual('(123)4567-890');
+		});
+
+		component.form.setValue({
+			value: 12345678901,
+		});
+		fixture.detectChanges();
+		inputEl = fixture.debugElement.query(By.css('input'));
+		Promise.resolve().then(() => {
+			expect(inputEl.nativeElement.value).toEqual('(123)4567-8901');
+		});
+
+		component.form.setValue({
+			value: 123456789012,
+		});
+		fixture.detectChanges();
+		inputEl = fixture.debugElement.query(By.css('input'));
+		Promise.resolve().then(() => {
+			expect(inputEl.nativeElement.value).toEqual('12-34567-89012');
+		});
+
+		component.mask = '00-00-00-00'; // For example Denmark phone format
+		fixture.detectChanges();
+
+		component.form.setValue({
+			value: 12345678,
+		});
+		fixture.detectChanges();
+		inputEl = fixture.debugElement.query(By.css('input'));
+		Promise.resolve().then(() => {
+			expect(inputEl.nativeElement.value).toEqual('12-34-56-78');
+		});
+	});
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When I try to change the mask from '(000)0000-000||(000)0000-0000||00-00000-00000' to '00-00-00-00'  directive does not clear `_maskExpressionArray` and if I update value in `FormControl` to remove extra characters directive will work with '(000)0000-000' mask instead of new '00-00-00-00'

## What is the new behavior?

After changing the mask, the directive will clear `_maskExpressionArray` if the new mask has only one string pattern.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
