### PR TITLE
fix(no-ref): separator logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="13.1.1"></a>
+
+# 13.1.1 (2022-01-12)
+
+### Fixes
+
+- Revision for separator logic.
+- Set default decimalMarker to [".",","] instead "."
+
 <a name="13.1.0"></a>
 
 # 13.1.0 (2021-12-30)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "awesome ngx mask",
   "license": "MIT",
   "engines": {

--- a/projects/ngx-mask-lib/package.json
+++ b/projects/ngx-mask-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mask",
-  "version": "13.0.1",
+  "version": "13.1.1",
   "description": "awesome ngx mask",
   "keywords": [
     "ng2-mask",

--- a/projects/ngx-mask-lib/src/lib/config.ts
+++ b/projects/ngx-mask-lib/src/lib/config.ts
@@ -4,7 +4,7 @@ export interface IConfig {
 	suffix: string;
 	prefix: string;
 	thousandSeparator: string;
-	decimalMarker: '.' | ',';
+	decimalMarker: '.' | ',' | ['.', ','];
 	clearIfNotMatch: boolean;
 	showTemplate: boolean;
 	showMaskTyped: boolean;
@@ -35,7 +35,7 @@ export const initialConfig: IConfig = {
 	suffix: '',
 	prefix: '',
 	thousandSeparator: ' ',
-	decimalMarker: '.',
+	decimalMarker: ['.', ','],
 	clearIfNotMatch: false,
 	showTemplate: false,
 	showMaskTyped: false,

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -160,30 +160,51 @@ export class MaskApplierService {
 				// eslint-disable-next-line no-param-reassign
 				inputValue = this._stripToDecimal(inputValue);
 			}
-
 			// eslint-disable-next-line no-param-reassign
 			inputValue =
 				inputValue.length > 1 &&
 				inputValue[0] === '0' &&
-				inputValue[1] !== this.decimalMarker &&
+				!this._compareOrIncludes(inputValue[1], this.decimalMarker, this.thousandSeparator) &&
 				!backspaced
 					? inputValue.slice(1, inputValue.length)
 					: inputValue;
 
+			if (backspaced) {
+				// eslint-disable-next-line no-param-reassign
+				inputValue = this._compareOrIncludes(
+					inputValue[inputValue.length - 1],
+					this.decimalMarker,
+					this.thousandSeparator,
+				)
+					? inputValue.slice(0, inputValue.length - 1)
+					: inputValue;
+			}
 			// TODO: we had different rexexps here for the different cases... but tests dont seam to bother - check this
 			//  separator: no COMMA, dot-sep: no SPACE, COMMA OK, comma-sep: no SPACE, COMMA OK
 
-			const thousandSeperatorCharEscaped: string = this._charToRegExpExpression(
+			const thousandSeparatorCharEscaped: string = this._charToRegExpExpression(
 				this.thousandSeparator,
 			);
-			const decimalMarkerEscaped: string = this._charToRegExpExpression(this.decimalMarker);
-			const invalidChars: string = '@#!$%^&*()_+|~=`{}\\[\\]:\\s,\\.";<>?\\/'
-				.replace(thousandSeperatorCharEscaped, '')
-				.replace(decimalMarkerEscaped, '');
+			let invalidChars: string = '@#!$%^&*()_+|~=`{}\\[\\]:\\s,\\.";<>?\\/'.replace(
+				thousandSeparatorCharEscaped,
+				'',
+			);
+			//.replace(decimalMarkerEscaped, '');
+			if (Array.isArray(this.decimalMarker)) {
+				for (const marker of this.decimalMarker) {
+					invalidChars = invalidChars.replace(this._charToRegExpExpression(marker), '');
+				}
+			} else {
+				invalidChars = invalidChars.replace(this._charToRegExpExpression(this.decimalMarker), '');
+			}
 
 			const invalidCharRegexp: RegExp = new RegExp('[' + invalidChars + ']');
 
-			if (inputValue.match(invalidCharRegexp)) {
+			if (
+				inputValue.match(invalidCharRegexp) ||
+				(inputValue.length === 1 &&
+					this._compareOrIncludes(inputValue, this.decimalMarker, this.thousandSeparator))
+			) {
 				// eslint-disable-next-line no-param-reassign
 				inputValue = inputValue.substring(0, inputValue.length - 1);
 			}
@@ -192,7 +213,7 @@ export class MaskApplierService {
 			// eslint-disable-next-line no-param-reassign
 			inputValue = this.checkInputPrecision(inputValue, precision, this.decimalMarker);
 			const strForSep: string = inputValue.replace(
-				new RegExp(thousandSeperatorCharEscaped, 'g'),
+				new RegExp(thousandSeparatorCharEscaped, 'g'),
 				'',
 			);
 			result = this._formatWithSeparators(
@@ -201,7 +222,6 @@ export class MaskApplierService {
 				this.decimalMarker,
 				precision,
 			);
-
 			const commaShift: number = result.indexOf(',') - inputValue.indexOf(',');
 			const shiftStep: number = result.length - inputValue.length;
 
@@ -473,10 +493,21 @@ export class MaskApplierService {
 	private _formatWithSeparators = (
 		str: string,
 		thousandSeparatorChar: string,
-		decimalChar: string,
+		decimalChars: string | string[],
 		precision: number,
 	) => {
-		const x: string[] = str.split(decimalChar);
+		let x: string[] = [];
+		let decimalChar: string = '';
+		if (Array.isArray(decimalChars)) {
+			const regExp = new RegExp(
+				decimalChars.map((v) => ('[\\^$.|?*+()'.indexOf(v) >= 0 ? `\\${v}` : v)).join('|'),
+			);
+			x = str.split(regExp);
+			decimalChar = str.match(regExp)?.[0] ?? '';
+		} else {
+			x = str.split(decimalChars);
+			decimalChar = decimalChars;
+		}
 		const decimals: string = x.length > 1 ? `${decimalChar}${x[1]}` : '';
 		let res: string = x[0]!;
 		const separatorLimit: string = this.separatorLimit.replace(/\s/g, '');
@@ -533,6 +564,12 @@ export class MaskApplierService {
 		decimalMarker: IConfig['decimalMarker'],
 	): string => {
 		if (precision < Infinity) {
+			// TODO need think about decimalMarker
+			if (Array.isArray(decimalMarker)) {
+				const marker = decimalMarker.find((dm) => dm !== this.thousandSeparator);
+				// eslint-disable-next-line no-param-reassign
+				decimalMarker = marker ? marker : decimalMarker[0];
+			}
 			const precisionRegEx: RegExp = new RegExp(
 				this._charToRegExpExpression(decimalMarker) + `\\d{${precision}}.*$`,
 			);
@@ -543,7 +580,14 @@ export class MaskApplierService {
 				// eslint-disable-next-line no-param-reassign
 				inputValue = inputValue.substring(0, inputValue.length - diff);
 			}
-			if (precision === 0 && inputValue.endsWith(decimalMarker)) {
+			if (
+				precision === 0 &&
+				this._compareOrIncludes(
+					inputValue[inputValue.length - 1],
+					decimalMarker,
+					this.thousandSeparator,
+				)
+			) {
 				// eslint-disable-next-line no-param-reassign
 				inputValue = inputValue.substring(0, inputValue.length - 1);
 			}
@@ -567,9 +611,12 @@ export class MaskApplierService {
 	}
 
 	private _charToRegExpExpression(char: string): string {
+		// if (Array.isArray(char)) {
+		// 	return char.map((v) => ('[\\^$.|?*+()'.indexOf(v) >= 0 ? `\\${v}` : v)).join('|');
+		// }
 		if (char) {
 			const charsToEscape = '[\\^$.|?*+()';
-			return char === ' ' ? '\\s' : charsToEscape.indexOf(char) >= 0 ? '\\' + char : char;
+			return char === ' ' ? '\\s' : charsToEscape.indexOf(char) >= 0 ? `\\${char}` : char;
 		}
 		return char;
 	}
@@ -577,5 +624,11 @@ export class MaskApplierService {
 	private _shiftStep(maskExpression: string, cursor: number, inputLength: number) {
 		const shiftStep: number = /[*?]/g.test(maskExpression.slice(0, cursor)) ? inputLength : cursor;
 		this._shift.add(shiftStep + this.prefix.length || 0);
+	}
+
+	protected _compareOrIncludes<T>(value: T, comparedValue: T | T[], excludedValue: T): boolean {
+		return Array.isArray(comparedValue)
+			? comparedValue.filter((v) => v !== excludedValue).includes(value)
+			: value === comparedValue;
 	}
 }

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -515,9 +515,11 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 		if (typeof inputValue === 'number') {
 			// eslint-disable-next-line no-param-reassign
 			inputValue = String(inputValue);
-			// eslint-disable-next-line no-param-reassign
-			inputValue =
-				this.decimalMarker !== '.' ? inputValue.replace('.', this.decimalMarker) : inputValue;
+			if (!Array.isArray(this.decimalMarker)) {
+				// eslint-disable-next-line no-param-reassign
+				inputValue =
+					this.decimalMarker !== '.' ? inputValue.replace('.', this.decimalMarker) : inputValue;
+			}
 			this._maskService.isNumberValue = true;
 		}
 

--- a/projects/ngx-mask-lib/src/lib/mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.service.ts
@@ -108,12 +108,11 @@ export class MaskService extends MaskApplierService {
 		// b) remove decimal marker from list of special characters to mask
 		if (this.maskExpression.startsWith('separator') && this.dropSpecialCharacters === true) {
 			this.maskSpecialCharacters = this.maskSpecialCharacters.filter(
-				(item: string) => item !== this.decimalMarker,
+				(item: string) =>
+					!this._compareOrIncludes(item, this.decimalMarker, this.thousandSeparator), //item !== this.decimalMarker, // !
 			);
 		}
-
 		this.formControlResult(result);
-
 		if (!this.showMaskTyped) {
 			if (this.hiddenInput) {
 				return result && result.length ? this.hideInput(result, this.maskExpression) : result;
@@ -420,7 +419,8 @@ export class MaskService extends MaskApplierService {
 
 		const separatorPrecision: number | null = this._retrieveSeparatorPrecision(this.maskExpression);
 		let separatorValue: string = this._retrieveSeparatorValue(result);
-		if (this.decimalMarker !== '.') {
+
+		if (this.decimalMarker !== '.' && !Array.isArray(this.decimalMarker)) {
 			separatorValue = separatorValue.replace(this.decimalMarker, '.');
 		}
 

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -475,4 +475,10 @@ describe('Separator: Mask', () => {
 
 		expect(inputTarget.selectionStart).toEqual(0);
 	});
+
+	it('Should work right when reset decimalMarker', () => {
+		component.mask = 'separator.2';
+		component.decimalMarker = ',';
+		equal('1000000,00', '1 000 000,00', fixture);
+	});
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Changed default configuration for decimalMarker ['.',','] instead '.'

Issue Number: N/A

## What is the new behavior?

Can use both decimal markers without additional configuration

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
