### PR TITLE
feat(lib): allow mask change to trigger onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="13.1.2"></a>
+
+# 13.1.2 (2022-01-20)
+
+### Features
+
+- added triggerOnMaskChange, allow mask change to trigger onChange
+
 <a name="13.1.1"></a>
 
 # 13.1.1 (2022-01-12)

--- a/projects/ngx-mask-lib/src/lib/config.ts
+++ b/projects/ngx-mask-lib/src/lib/config.ts
@@ -17,6 +17,7 @@ export interface IConfig {
 	separatorLimit: string;
 	allowNegativeNumbers: boolean;
 	leadZeroDateTime: boolean;
+	triggerOnMaskChange: boolean;
 	patterns: {
 		[character: string]: {
 			pattern: RegExp;
@@ -49,6 +50,7 @@ export const initialConfig: IConfig = {
 	// eslint-disable-next-line @typescript-eslint/quotes
 	specialCharacters: ['-', '/', '(', ')', '.', ':', ' ', '+', ',', '@', '[', ']', '"', "'"],
 	leadZeroDateTime: false,
+	triggerOnMaskChange: false,
 	patterns: {
 		'0': {
 			pattern: new RegExp('\\d'),

--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -75,6 +75,8 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 
 	@Input() public leadZeroDateTime: IConfig['leadZeroDateTime'] | null = null;
 
+	@Input() public triggerOnMaskChange: IConfig['triggerOnMaskChange'] | null = null;
+
 	private _maskValue: string = '';
 
 	private _inputValue!: string;
@@ -121,6 +123,7 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 			separatorLimit,
 			allowNegativeNumbers,
 			leadZeroDateTime,
+			triggerOnMaskChange,
 		} = changes;
 		if (maskExpression) {
 			if (
@@ -204,6 +207,9 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 		}
 		if (leadZeroDateTime) {
 			this._maskService.leadZeroDateTime = leadZeroDateTime.currentValue;
+		}
+		if (triggerOnMaskChange) {
+			this._maskService.triggerOnMaskChange = triggerOnMaskChange.currentValue;
 		}
 		this._applyMask();
 	}

--- a/projects/ngx-mask-lib/src/lib/mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.service.ts
@@ -26,6 +26,8 @@ export class MaskService extends MaskApplierService {
 
 	public maskChanged: boolean = false;
 
+	public triggerOnMaskChange: boolean = false;
+
 	public onChange = (_: any) => {};
 
 	public constructor(
@@ -352,7 +354,7 @@ export class MaskService extends MaskApplierService {
 	 * @param inputValue the current form input value
 	 */
 	private formControlResult(inputValue: string): void {
-		if (this.writingValue || this.maskChanged) {
+		if (this.writingValue || (!this.triggerOnMaskChange && this.maskChanged)) {
 			this.maskChanged = false;
 			return;
 		}

--- a/projects/ngx-mask-lib/src/test/delete.cy-spec.ts
+++ b/projects/ngx-mask-lib/src/test/delete.cy-spec.ts
@@ -1,8 +1,6 @@
 import { mount } from '@jscutlery/cypress-angular/mount';
-import {
-	CypressTestMaskComponent,
-	CypressTestMaskModule,
-} from './utils/cypress-test-component.component';
+import { CypressTestMaskComponent } from './utils/cypress-test-component.component';
+import { CypressTestMaskModule } from './utils/cypress-test.module';
 
 describe('Directive: Mask (Delete)', () => {
 	it('should delete character in input', () => {
@@ -13,13 +11,12 @@ describe('Directive: Mask (Delete)', () => {
 			imports: [CypressTestMaskModule],
 		});
 
-		const inputTarget = cy.get('input');
-		inputTarget.type('12/34/5678');
-		inputTarget.focus();
-		inputTarget.setSelectionRange(1, 1);
-		inputTarget.type('{backspace}');
-
-		inputTarget.should('have.value', '23/45/678');
+		cy.get('input#masked')
+			.type('12/34/5678')
+			.focus()
+			.setSelectionRange(1, 1)
+			.type('{backspace}')
+			.should('have.value', '23/45/678');
 	});
 
 	it('should not delete special mask character', () => {
@@ -30,13 +27,12 @@ describe('Directive: Mask (Delete)', () => {
 			imports: [CypressTestMaskModule],
 		});
 
-		const inputTarget = cy.get('input');
-		inputTarget.type('12/34/5678');
-		inputTarget.setSelectionRange(3, 3);
-		inputTarget.type('{backspace}');
-
-		inputTarget.should('have.value', '12/34/5678');
-		inputTarget.should('have.prop', 'selectionStart', 2);
+		cy.get('input#masked')
+			.type('12/34/5678')
+			.setSelectionRange(3, 3)
+			.type('{backspace}')
+			.should('have.value', '12/34/5678')
+			.should('have.prop', 'selectionStart', 2);
 	});
 
 	it('should delete secure character', () => {
@@ -48,13 +44,12 @@ describe('Directive: Mask (Delete)', () => {
 			imports: [CypressTestMaskModule],
 		});
 
-		const inputTarget = cy.get('input');
-		inputTarget.type('123/45/6789');
-		inputTarget.setSelectionRange(3, 3);
-		inputTarget.type('{backspace}');
-
-		inputTarget.should('have.value', '***/*6/789');
-		inputTarget.should('have.prop', 'selectionStart', 2);
+		cy.get('input#masked')
+			.type('123/45/6789')
+			.setSelectionRange(3, 3)
+			.type('{backspace}')
+			.should('have.value', '***/*6/789')
+			.should('have.prop', 'selectionStart', 2);
 	});
 
 	it('should not delete prefix', () => {
@@ -66,13 +61,12 @@ describe('Directive: Mask (Delete)', () => {
 			imports: [CypressTestMaskModule],
 		});
 
-		const inputTarget = cy.get('input');
-		inputTarget.type('1234');
-		inputTarget.setSelectionRange(3, 3);
-		inputTarget.type('{backspace}');
-
-		inputTarget.should('have.value', '+1 (12) 34');
-		inputTarget.should('have.prop', 'selectionStart', 3);
+		cy.get('input#masked')
+			.type('1234')
+			.setSelectionRange(3, 3)
+			.type('{backspace}')
+			.should('have.value', '+1 (12) 34')
+			.should('have.prop', 'selectionStart', 3);
 	});
 
 	it('should delete selection', () => {
@@ -83,12 +77,11 @@ describe('Directive: Mask (Delete)', () => {
 			imports: [CypressTestMaskModule],
 		});
 
-		const inputTarget = cy.get('input');
-		inputTarget.type('123456789');
-		inputTarget.setSelectionRange(4, 7);
-		inputTarget.type('{backspace}');
-
-		inputTarget.should('have.value', '123 789');
-		inputTarget.should('have.prop', 'selectionStart', 3);
+		cy.get('input#masked')
+			.type('123456789')
+			.setSelectionRange(4, 7)
+			.type('{backspace}')
+			.should('have.value', '123 789')
+			.should('have.prop', 'selectionStart', 3);
 	});
 });

--- a/projects/ngx-mask-lib/src/test/trigger-on-mask-change.cy-spec.ts
+++ b/projects/ngx-mask-lib/src/test/trigger-on-mask-change.cy-spec.ts
@@ -1,0 +1,23 @@
+import { mount } from '@jscutlery/cypress-angular/mount';
+
+import { CypressTestTriggerOnMaskChangeComponent } from './utils/cypress-test-trigger-on-mask-change.component';
+import { CypressTestMaskModule } from './utils/cypress-test.module';
+
+describe('Directive: Mask (Trigger on mask change) [Cypress]', () => {
+	it('should put back initial value if mask is toggled', async () => {
+		mount(CypressTestTriggerOnMaskChangeComponent, {
+			imports: [CypressTestMaskModule],
+		});
+
+		cy.get('input#masked').type('7912345678').should('have.value', '7912345678');
+		cy.get('.formvalue').should('have.text', '7912345678');
+
+		cy.get('input[value="ch"]').click();
+		cy.get('input#masked').should('have.value', '79 123 45 67');
+		cy.get('.formvalue').should('have.text', '791234567');
+
+		cy.get('input[value="de"]').click();
+		cy.get('input#masked').should('have.value', '7912345678');
+		cy.get('.formvalue').should('have.text', '7912345678');
+	});
+});

--- a/projects/ngx-mask-lib/src/test/trigger-on-mask-change.spec.ts
+++ b/projects/ngx-mask-lib/src/test/trigger-on-mask-change.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+import { NgxMaskModule } from '../lib/ngx-mask.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TestMaskComponent } from './utils/test-component.component';
+
+describe('Directive: Mask (Trigger on mask change)', () => {
+	let fixture: ComponentFixture<TestMaskComponent>;
+	let component: TestMaskComponent;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [TestMaskComponent],
+			imports: [ReactiveFormsModule, NgxMaskModule.forRoot()],
+		});
+		fixture = TestBed.createComponent(TestMaskComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+	});
+
+	it('should trigger form value update if mask is changed', async () => {
+		component.mask = '';
+		component.triggerOnMaskChange = true;
+		fixture.detectChanges();
+
+		component.form.setValue('7912345678');
+		fixture.detectChanges();
+		await fixture.whenStable();
+		let inputEl = fixture.debugElement.query(By.css('input'));
+		expect(inputEl.nativeElement.value).toEqual('7912345678');
+		expect(component.form.value).toEqual('7912345678');
+
+		component.mask = '00 000 00 00';
+		fixture.detectChanges();
+		await fixture.whenStable();
+		inputEl = fixture.debugElement.query(By.css('input'));
+		expect(inputEl.nativeElement.value).toEqual('79 123 45 67');
+		expect(component.form.value).toEqual('791234567');
+	});
+});

--- a/projects/ngx-mask-lib/src/test/utils/cypress-test-component.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/cypress-test-component.component.ts
@@ -1,14 +1,11 @@
-import { Component, Input, NgModule } from '@angular/core';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-
-import { CommonModule } from '@angular/common';
-import { NgxMaskModule } from 'ngx-mask';
+import { Component, Input } from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 @Component({
 	selector: 'mask-cypress-test-mask',
 	template: `
 		<input
-			id="maska"
+			id="masked"
 			[formControl]="form"
 			[mask]="mask"
 			[hiddenInput]="hiddenInput"
@@ -25,10 +22,3 @@ export class CypressTestMaskComponent {
 
 	public form: FormControl = new FormControl('');
 }
-
-@NgModule({
-	imports: [CommonModule, ReactiveFormsModule, FormsModule, NgxMaskModule.forRoot()],
-	declarations: [CypressTestMaskComponent],
-	exports: [CypressTestMaskComponent],
-})
-export class CypressTestMaskModule {}

--- a/projects/ngx-mask-lib/src/test/utils/cypress-test-trigger-on-mask-change.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/cypress-test-trigger-on-mask-change.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { Subject, takeUntil } from 'rxjs';
+
+@Component({
+	selector: 'mask-cypress-test-mask',
+	styles: [
+		'code { border: 1px solid #ddd; background-color: #eee; padding: 0 5px; border-radius: 3px; }',
+	],
+	template: `
+		<div>
+			<label>
+				<input type="radio" [formControl]="radio" value="de" />
+				DE
+			</label>
+			<label>
+				<input type="radio" [formControl]="radio" value="ch" />
+				CH
+			</label>
+
+			<input
+				id="masked"
+				[formControl]="form"
+				[mask]="mask"
+				[hiddenInput]="false"
+				[triggerOnMaskChange]="true"
+				prefix=""
+			/>
+		</div>
+		<div>
+			<span>Mask:&nbsp;</span><code class="mask">{{ mask }}</code>
+			<br />
+			<span>Form Value:&nbsp;</span><code class="formvalue">{{ form.value }}</code>
+		</div>
+	`,
+})
+export class CypressTestTriggerOnMaskChangeComponent implements OnInit, OnDestroy {
+	public mask: string = '';
+
+	public form: FormControl = new FormControl('');
+
+	public radio: FormControl = new FormControl('de');
+
+	private destroyed = new Subject<void>();
+
+	public ngOnInit(): void {
+		this.radio.valueChanges.pipe(takeUntil(this.destroyed)).subscribe((value) => {
+			this.mask = value === 'de' ? '' : '00 000 00 00';
+		});
+	}
+
+	public ngOnDestroy(): void {
+		this.destroyed.next();
+		this.destroyed.complete();
+	}
+}

--- a/projects/ngx-mask-lib/src/test/utils/cypress-test.module.ts
+++ b/projects/ngx-mask-lib/src/test/utils/cypress-test.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgxMaskModule } from 'ngx-mask';
+import { CypressTestTriggerOnMaskChangeComponent } from './cypress-test-trigger-on-mask-change.component';
+import { CypressTestMaskComponent } from './cypress-test-component.component';
+
+@NgModule({
+	imports: [CommonModule, ReactiveFormsModule, FormsModule, NgxMaskModule.forRoot()],
+	declarations: [CypressTestMaskComponent, CypressTestTriggerOnMaskChangeComponent],
+	exports: [CypressTestMaskComponent, CypressTestTriggerOnMaskChangeComponent],
+})
+export class CypressTestMaskModule {}

--- a/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
@@ -24,6 +24,7 @@ import { IConfig } from '../../lib/config';
 			[hiddenInput]="hiddenInput"
 			[allowNegativeNumbers]="allowNegativeNumbers"
 			[leadZeroDateTime]="leadZeroDateTime"
+			[triggerOnMaskChange]="triggerOnMaskChange"
 		/>
 	`,
 })
@@ -59,4 +60,6 @@ export class TestMaskComponent {
 	public allowNegativeNumbers: IConfig['allowNegativeNumbers'] = false;
 
 	public leadZeroDateTime: IConfig['leadZeroDateTime'] = false;
+
+	public triggerOnMaskChange: IConfig['triggerOnMaskChange'] = false;
 }

--- a/src/app/showcase/showcase.component.html
+++ b/src/app/showcase/showcase.component.html
@@ -1053,3 +1053,45 @@
     </div>
   </div>
 </div>
+
+<div class="container">
+  <div class="row">
+    <div class="col-12">
+      <div class="mat-card-wr">
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title>Trigger onChange on mask change</mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <div class="flex-row">
+              <div class="flex-cell">
+                <mat-form-field class="">
+                  <mat-label>Phone prefix</mat-label>
+                  <mat-select [formControl]="triggerSelectFormControl">
+                    <mat-option value="ch">+41</mat-option>
+                    <mat-option value="de">+49</mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <mat-form-field>
+                  <mat-label>Phone number</mat-label>
+                  <input
+                    matInput
+                    [mask]="triggerMask"
+                    [formControl]="triggerInputFormControl"
+                    [triggerOnMaskChange]="true"
+                  />
+                  <mat-hint><b>Mask:</b>{{ triggerMask ?? 'Empty' }}</mat-hint>
+                </mat-form-field>
+              </div>
+              <div class="flex-cell">
+                <p>
+                  <b>FormControl:</b> {{ triggerInputFormControl.value ?? 'Empty' }}
+                </p>
+              </div>
+            </div>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/showcase/showcase.component.ts
+++ b/src/app/showcase/showcase.component.ts
@@ -155,6 +155,12 @@ export class ShowcaseComponent {
 
 	public spacebarZeroPrecisionSeparatorForm!: FormControl;
 
+	public triggerSelectFormControl!: FormControl;
+
+	public triggerInputFormControl!: FormControl;
+
+	public triggerMask = '';
+
 	public constructor() {
 		this.form = new FormControl('');
 		this.form1 = new FormControl('');
@@ -190,6 +196,11 @@ export class ShowcaseComponent {
 		this.hour24Form = new FormControl('');
 		this.mixedTypeForm = new FormControl('');
 		this.dateMonthForm = new FormControl('');
+		this.triggerSelectFormControl = new FormControl('de');
+		this.triggerSelectFormControl.valueChanges.subscribe((value) => {
+			this.triggerMask = value === 'de' ? '' : '00 000 00 00';
+		});
+		this.triggerInputFormControl = new FormControl('123456789');
 
 		this.customMaska = ['PPP-PPP-PPP', this.pattern];
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
If the mask is dynamically set via the mask input and the value changes, then the `onChange` is not called.

## What is the new behavior?
If we set `triggerOnMaskChange` and the value changes because the mask has e.g. a different length, then the `onChange` function is called with the new value. 

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
