### PR TITLE
fix(mask.service.ts): replacing comma with dot when decimalMarker is …

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.service.ts
@@ -442,17 +442,21 @@ export class MaskService extends MaskApplierService {
 		);
 	}
 
+	private _replaceDecimalMarkerToDot(value: string): string {
+		const markers = Array.isArray(this.decimalMarker) ? this.decimalMarker : [this.decimalMarker];
+
+		return value.replace(this._regExpForRemove(markers), '.');
+	}
+
 	private _checkSymbols(result: string): string | number | undefined | null {
 		if (result === '') {
 			return result;
 		}
 
 		const separatorPrecision: number | null = this._retrieveSeparatorPrecision(this.maskExpression);
-		let separatorValue: string = this._retrieveSeparatorValue(result);
-
-		if (this.decimalMarker !== '.' && !Array.isArray(this.decimalMarker)) {
-			separatorValue = separatorValue.replace(this.decimalMarker, '.');
-		}
+		const separatorValue: string = this._replaceDecimalMarkerToDot(
+			this._retrieveSeparatorValue(result),
+		);
 
 		if (!this.isNumberValue) {
 			return separatorValue;

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -4,7 +4,7 @@ import { DebugElement } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NgxMaskModule } from '../lib/ngx-mask.module';
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal } from './utils/test-functions.component';
+import { equal, typeTest } from './utils/test-functions.component';
 
 describe('Separator: Mask', () => {
 	let fixture: ComponentFixture<TestMaskComponent>;
@@ -528,5 +528,26 @@ describe('Separator: Mask', () => {
 		component.thousandSeparator = '.';
 		component.decimalMarker = ',';
 		equal('12345,67', '12.345,67', fixture);
+	});
+
+	it('check formControl value to be number when decimalMarker is comma', () => {
+		component.mask = 'separator.2';
+		component.thousandSeparator = ' ';
+		component.decimalMarker = ',';
+
+		typeTest('12 345,67', fixture);
+		expect(component.form.value).toBe('12345.67');
+	});
+
+	it('check formControl value to be number when decimalMarker is array', () => {
+		component.mask = 'separator.2';
+		component.thousandSeparator = ' ';
+		component.decimalMarker = ['.', ','];
+
+		typeTest('12 345,67', fixture);
+		expect(component.form.value).toBe('12345.67');
+
+		typeTest('123 456.78', fixture);
+		expect(component.form.value).toBe('123456.78');
 	});
 });


### PR DESCRIPTION
…array

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When we set decimalMarker as and array and typing 100,10 formControl value will be NaN
```html
<input [formControl]="control" type="text" thousandSeparator="" [decimalMarker]="['.', ',']" mask="separator.2" />
```

Issue Number: N/A

## What is the new behavior?
typing 100,10 formControl value will be 100.10

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
