### PR TITLE
fix(943): if last character of suffix same as first letter inputted d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mask",
-  "version": "14.2.2",
+  "version": "14.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mask",
-      "version": "14.2.2",
+      "version": "14.2.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.1",

--- a/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/mask-applier.service.ts
@@ -561,6 +561,7 @@ export class MaskApplierService {
 			const substr = this.suffix.substr(i, this.suffix?.length);
 			if (
 				inputValue.includes(substr) &&
+				i !== this.suffix?.length - 1 &&
 				(i - 1 < 0 || !inputValue.includes(this.suffix.substr(i - 1, this.suffix?.length)))
 			) {
 				return inputValue.replace(substr, '');

--- a/projects/ngx-mask-lib/src/test/add-suffix.spec.ts
+++ b/projects/ngx-mask-lib/src/test/add-suffix.spec.ts
@@ -24,4 +24,16 @@ describe('Directive: Mask (Add suffix)', () => {
 		component.suffix = '$';
 		equal('6', '6$', fixture);
 	});
+
+	it('should have a suffix if first letter entered is y', () => {
+		component.mask = 'L{80}';
+		component.suffix = '.sh';
+		equal('y', 'y.sh', fixture);
+	});
+
+	it('should have a suffix if first charachter entered same as last letter of suffix', () => {
+		component.mask = 'L{80}';
+		component.suffix = '.sh';
+		equal('h', 'h.sh', fixture);
+	});
 });

--- a/projects/ngx-mask-lib/src/test/add-suffix.spec.ts
+++ b/projects/ngx-mask-lib/src/test/add-suffix.spec.ts
@@ -31,7 +31,7 @@ describe('Directive: Mask (Add suffix)', () => {
 		equal('y', 'y.sh', fixture);
 	});
 
-	it('should have a suffix if first charachter entered same as last letter of suffix', () => {
+	it('should have a suffix if the first character entered same as the last letter of the suffix', () => {
 		component.mask = 'L{80}';
 		component.suffix = '.sh';
 		equal('h', 'h.sh', fixture);


### PR DESCRIPTION
…o not remove

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

If a suffix such as `.sh` is added to the mask, and the first character a user inputs(e.g. `h`) is the last letter of the mask(e.g. `.sh`) it will not allow the character(`h`) to be inputted. 

Issue Number: [943](https://github.com/JsDaddy/ngx-mask/issues/943)

## What is the new behavior?
If it is the first character inputted, the assumption is always that it should be added to side step includes logic. All existing unit tests currently pass. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Fixes the issue here: https://github.com/JsDaddy/ngx-mask/issues/943
