### PR TITLE
fix(1009): decimalMarker not locale default

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -545,10 +545,11 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
             // eslint-disable-next-line no-param-reassign
             inputValue = this._maskService.numberToString(inputValue);
             if (!Array.isArray(this.decimalMarker)) {
+                const localeDecimalMarker = this._currentLocaleDecimalMarker();
                 // eslint-disable-next-line no-param-reassign
                 inputValue =
-                    this.decimalMarker !== '.'
-                        ? inputValue.replace('.', this.decimalMarker)
+                    this.decimalMarker !== localeDecimalMarker
+                        ? inputValue.replace(localeDecimalMarker, this.decimalMarker)
                         : inputValue;
             }
             this._maskService.isNumberValue = true;
@@ -702,5 +703,9 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
                 }
             });
         }
+    }
+
+    private _currentLocaleDecimalMarker(): string {
+        return (1.1).toLocaleString().substring(1, 2);
     }
 }

--- a/src/app/showcase/showcase.component.html
+++ b/src/app/showcase/showcase.component.html
@@ -21,6 +21,56 @@
             <div class="mat-card-wr">
                 <mat-card>
                     <mat-card-header>
+                        <mat-card-title>Decimal separator with existing value</mat-card-title>
+                        <mat-card-subtitle></mat-card-subtitle>
+                    </mat-card-header>
+                    <mat-card-content>
+                        <div class="flex-row">
+                            <div class="flex-cell-padding">
+                                <mat-form-field>
+                                    <input
+                                        matInput
+                                        placeholder="Separator"
+                                        [dropSpecialCharacters]="true"
+                                        mask="separator.2"
+                                        decimalMarker="."
+                                        [formControl]="initializedDecimalSeparatorForm"
+                                        [(ngModel)]="initializedDecimalSeparatorFormModel" />
+                                    <mat-hint><b>Mask: </b>separator.2, decimalMarker '.'</mat-hint>
+                                </mat-form-field>
+                            </div>
+                            <div class="flex-cell">
+                                <p>
+                                    <b>FormControl:</b>
+                                    {{
+                                        initializedDecimalSeparatorForm.value
+                                            ? initializedDecimalSeparatorForm.value
+                                            : 'Empty'
+                                    }}
+                                </p>
+                                <p>
+                                    <b>NgModel:</b>
+                                    {{
+                                        initializedDecimalSeparatorFormModel
+                                            ? initializedDecimalSeparatorFormModel
+                                            : 'Empty'
+                                    }}
+                                </p>
+                            </div>
+                        </div>
+                    </mat-card-content>
+                </mat-card>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="row">
+        <div class="col-12">
+            <div class="mat-card-wr">
+                <mat-card>
+                    <mat-card-header>
                         <mat-card-title>Mask common case</mat-card-title>
                         <mat-card-subtitle>Secure Input</mat-card-subtitle>
                     </mat-card-header>

--- a/src/app/showcase/showcase.component.ts
+++ b/src/app/showcase/showcase.component.ts
@@ -51,6 +51,8 @@ export class ShowcaseComponent {
 
     public emptyMaskForm: FormControl;
 
+    public initializedDecimalSeparatorForm: FormControl;
+
     public separatorForm: FormControl;
 
     public percent: FormControl;
@@ -112,6 +114,8 @@ export class ShowcaseComponent {
     public customPatternFormModel!: SN;
 
     public separatorFormModel!: SN;
+
+    public initializedDecimalSeparatorFormModel = 1234.56;
 
     public separatorPrecisionSeparatorFormModel!: SN;
 
@@ -184,6 +188,7 @@ export class ShowcaseComponent {
         this.repeatForm = new FormControl('');
         this.emptyMaskForm = new FormControl('');
         this.separatorForm = new FormControl('');
+        this.initializedDecimalSeparatorForm = new FormControl('');
         this.separatorPrecisionSeparatorForm = new FormControl('');
         this.separatorZeroPrecisionSeparatorForm = new FormControl('');
         this.dotSeparatorForm = new FormControl('');


### PR DESCRIPTION
note: manually tested with added showcase
"Decimal separator with existing value"

of course, if someone finds a way to mock/set the locale
in the tests, I'll gladly add a unit test for that :)

to test: set browser locale to German for instance
(so that decimal marker defaults to ',')

before fix: 1234.56 shows as 1234.5
after fix: 1234.56 shows as 1234.56