### PR TITLE
fix(1069): input seleciontStart goes to wrong position after dynamic mask changes while typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
+<a name="15.0.3"></a>
+
+# 15.0.3(2023-02-20)
+
+### Fix
+- Fix ([#1069](https://github.com/JsDaddy/ngx-mask/issues/1069))
+
+<a name="15.0.2"></a>
+
+# 15.0.2(2022-12-26)
+
+### Fix
+- Fix README.md
+
+<a name="15.0.1">
+
 # 15.0.1(2022-26-12)
 
 ### Fix
 - separate `provideEnvironmentNgxMask` and `provideNgxMask`
 
-<a name="15.0.1"></a>
+<a name="15.0.0"></a>
 
 # 15.0.0(2022-19-12)
 
@@ -17,7 +33,7 @@
 
 ### Fix
 - Fix ([#1039](https://github.com/JsDaddy/ngx-mask/issues/1039))
-- new code and styles linting rules formatting 
+- new code and styles linting rules formatting
 
 <a name="14.2.3"></a>
 
@@ -41,7 +57,7 @@
 # 14.2.1(2022-09-11)
 
 ### Fix
-- package build process 
+- package build process
 
 
 <a name="14.2.0"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ngx-mask",
-    "version": "15.0.2",
+    "version": "15.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ngx-mask",
-            "version": "15.0.2",
+            "version": "15.0.3",
             "license": "MIT",
             "dependencies": {
                 "@angular/animations": "15.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-mask",
-    "version": "15.0.2",
+    "version": "15.0.3",
     "description": "Awesome ngx mask",
     "license": "MIT",
     "engines": {

--- a/projects/ngx-mask-lib/package.json
+++ b/projects/ngx-mask-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-mask",
-    "version": "15.0.2",
+    "version": "15.0.3",
     "description": "awesome ngx mask",
     "keywords": [
         "ng2-mask",

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -330,7 +330,7 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
             this.onChange(el.value);
             return;
         }
-        const position: number =
+        let position: number =
             el.selectionStart === 1
                 ? (el.selectionStart as number) + this._maskService.prefix.length
                 : (el.selectionStart as number);
@@ -350,6 +350,15 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
         if (this._getActiveElement() !== el) {
             return;
         }
+
+        // update position after applyValueChanges to prevent cursor on wrong position when it has an array of maskExpression
+        if (this._maskExpressionArray.length) {
+            position =
+                el.selectionStart === 1
+                    ? (el.selectionStart as number) + this._maskService.prefix.length
+                    : (el.selectionStart as number);
+        }
+
         this._position =
             this._position === 1 && this._inputValue.length === 1 ? null : this._position;
         let positionToApply: number = this._position

--- a/projects/ngx-mask-lib/src/test/dynamic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/dynamic.spec.ts
@@ -153,4 +153,31 @@ describe('Directive: Mask (Dynamic)', () => {
             value: '12345.67',
         });
     });
+
+    it("Should update position to the end of input when mask changes while typing", async () => {
+      component.mask = "(00) 00000000||+00 (00) 00000000";
+      const debugElement: DebugElement = fixture.debugElement.query(By.css("input"));
+      const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+      spyOnProperty(document, "activeElement").and.returnValue(inputTarget);
+      fixture.detectChanges();
+
+      inputTarget.value = "5549362216";
+      inputTarget.selectionStart = 13;
+      inputTarget.selectionEnd = 13;
+      debugElement.triggerEventHandler("input", { target: inputTarget });
+
+      expect(inputTarget.value).toBe("(55) 49362216");
+      expect(inputTarget.selectionStart).toEqual(13);
+
+      debugElement.nativeElement.value += "8";
+
+      debugElement.triggerEventHandler("input", {
+        target: debugElement.nativeElement,
+      });
+
+      fixture.detectChanges();
+
+      expect(inputTarget.value).toBe("+55 (49) 3622168");
+      expect(inputTarget.selectionStart).toEqual(16);
+    });
 });

--- a/projects/ngx-mask-lib/src/test/dynamic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/dynamic.spec.ts
@@ -154,30 +154,30 @@ describe('Directive: Mask (Dynamic)', () => {
         });
     });
 
-    it("Should update position to the end of input when mask changes while typing", async () => {
-      component.mask = "(00) 00000000||+00 (00) 00000000";
-      const debugElement: DebugElement = fixture.debugElement.query(By.css("input"));
-      const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
-      spyOnProperty(document, "activeElement").and.returnValue(inputTarget);
-      fixture.detectChanges();
+    it('Should update position to the end of input when mask changes while typing', async () => {
+        component.mask = '(00) 00000000||+00 (00) 00000000';
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
 
-      inputTarget.value = "5549362216";
-      inputTarget.selectionStart = 13;
-      inputTarget.selectionEnd = 13;
-      debugElement.triggerEventHandler("input", { target: inputTarget });
+        inputTarget.value = '5549362216';
+        inputTarget.selectionStart = 13;
+        inputTarget.selectionEnd = 13;
+        debugElement.triggerEventHandler('input', { target: inputTarget });
 
-      expect(inputTarget.value).toBe("(55) 49362216");
-      expect(inputTarget.selectionStart).toEqual(13);
+        expect(inputTarget.value).toBe('(55) 49362216');
+        expect(inputTarget.selectionStart).toEqual(13);
 
-      debugElement.nativeElement.value += "8";
+        debugElement.nativeElement.value += '8';
 
-      debugElement.triggerEventHandler("input", {
-        target: debugElement.nativeElement,
-      });
+        debugElement.triggerEventHandler('input', {
+            target: debugElement.nativeElement,
+        });
 
-      fixture.detectChanges();
+        fixture.detectChanges();
 
-      expect(inputTarget.value).toBe("+55 (49) 3622168");
-      expect(inputTarget.selectionStart).toEqual(16);
+        expect(inputTarget.value).toBe('+55 (49) 3622168');
+        expect(inputTarget.selectionStart).toEqual(16);
     });
 });

--- a/src/assets/content/commonCases.ts
+++ b/src/assets/content/commonCases.ts
@@ -44,6 +44,13 @@ export const ComDocs: IComDoc[] = [
         id: 6,
         anchor: 'validdate',
     },
+    {
+        header: 'Dynamic mask',
+        text: '',
+        code: `<input type='text' mask="(00) 00000000||+00 (00) 00000000" >`,
+        id: 7,
+        anchor: 'dynamic-mask',
+    },
 ];
 
 export const ComExamples: TExample<IMaskOptions>[] = [
@@ -77,4 +84,9 @@ export const ComExamples: TExample<IMaskOptions>[] = [
         _mask: 'd0/M0/0000',
         control: { form: new UntypedFormControl(''), model: '' },
     },
+    {
+        _placeholder: 'Dynamic',
+        _mask: '(00) 00000000||+00 (00) 00000000',
+        control: { form: new UntypedFormControl(''), model: '' },
+    }
 ];

--- a/src/assets/content/commonCases.ts
+++ b/src/assets/content/commonCases.ts
@@ -88,5 +88,5 @@ export const ComExamples: TExample<IMaskOptions>[] = [
         _placeholder: 'Dynamic',
         _mask: '(00) 00000000||+00 (00) 00000000',
         control: { form: new UntypedFormControl(''), model: '' },
-    }
+    },
 ];


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When an input with dynamic mask changes from the smaller mask to the bigger mask, the caret position (selectionStart) stays in the middle of the input, instead of going to the end of it

Issue Number: #1069 

## What is the new behavior?
When an input with dynamic mask changes from the smaller mask to the bigger mask, the caret position (selectionStart) goes to the end of it, following the typed text

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information