### PR TITLE
fix(#1135): incorrect result when IME composition event is active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ngx-mask",
-    "version": "15.1.2",
+    "version": "15.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ngx-mask",
-            "version": "15.1.2",
+            "version": "15.1.3",
             "license": "MIT",
             "dependencies": {
                 "@angular/animations": "15.2.8",

--- a/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
@@ -447,6 +447,7 @@ describe('Directive: Mask', () => {
         spyOn(directiveInstance._maskService, 'applyMask');
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });

--- a/projects/ngx-mask-lib/src/test/delete.spec.ts
+++ b/projects/ngx-mask-lib/src/test/delete.spec.ts
@@ -35,6 +35,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 1;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -56,6 +57,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 3;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -78,6 +80,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 7;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -99,6 +102,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 1;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -120,6 +124,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 4;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 46,
             target: inputTarget,
         });
@@ -132,6 +137,7 @@ describe('Directive: Mask (Delete)', () => {
 
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -153,6 +159,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 1;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -175,6 +182,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 1;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -197,6 +205,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 3;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -219,6 +228,7 @@ describe('Directive: Mask (Delete)', () => {
         inputTarget.selectionEnd = 4;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
             // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -360,6 +360,7 @@ describe('Separator: Mask', () => {
         inputTarget.selectionEnd = 6;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -381,6 +382,7 @@ describe('Separator: Mask', () => {
         inputTarget.selectionEnd = 6;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -403,6 +405,7 @@ describe('Separator: Mask', () => {
         inputTarget.selectionEnd = 8;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -424,6 +427,7 @@ describe('Separator: Mask', () => {
         inputTarget.selectionEnd = 8;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -446,6 +450,7 @@ describe('Separator: Mask', () => {
         inputTarget.selectionEnd = 2;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });

--- a/projects/ngx-mask-lib/src/test/test-sufix.spec.ts
+++ b/projects/ngx-mask-lib/src/test/test-sufix.spec.ts
@@ -68,6 +68,7 @@ describe('Directive: Mask (Suffix)', () => {
         inputTarget.selectionEnd = 5;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });
@@ -107,6 +108,7 @@ describe('Directive: Mask (Suffix)', () => {
         inputTarget.selectionEnd = 10;
         debugElement.triggerEventHandler('keydown', {
             code: 'Backspace',
+            key: 'Backspace',
             keyCode: 8,
             target: inputTarget,
         });


### PR DESCRIPTION
- when composition event is active, pause input and keydown event  until user confirms their choice.
- Replace deprecated `keyCode` using `key`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Issue Number: #1135

## What is the new behavior?

Text will be input only after composition event is ended. Hence, everything will work fine.

Microsoft Bopomofo:
![MicrosoftBopomofo_corrected](https://github.com/JsDaddy/ngx-mask/assets/64851043/4d9f0a6d-7481-42c8-8aa0-bde3cc23cc45)

Microsoft Japanese:
![MicrosoftJapanese_corrected](https://github.com/JsDaddy/ngx-mask/assets/64851043/714bd27d-abc5-43cb-ab80-70dca909b1ec)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No