### PR TITLE
fix(#1066): fixed decimal formatting bug when using provideEnvironmentNgxMask()

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -554,12 +554,12 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
         if (typeof inputValue === 'number' || this._maskValue.startsWith('separator')) {
             // eslint-disable-next-line no-param-reassign
             inputValue = this._maskService.numberToString(inputValue);
-            if (!Array.isArray(this.decimalMarker)) {
+            if (!Array.isArray(this._maskService.decimalMarker)) {
                 const localeDecimalMarker = this._currentLocaleDecimalMarker();
                 // eslint-disable-next-line no-param-reassign
                 inputValue =
-                    this.decimalMarker !== localeDecimalMarker
-                        ? inputValue.replace(localeDecimalMarker, this.decimalMarker)
+                    this._maskService.decimalMarker !== localeDecimalMarker
+                        ? inputValue.replace(localeDecimalMarker, this._maskService.decimalMarker)
                         : inputValue;
             }
             this._maskService.isNumberValue = true;

--- a/projects/ngx-mask-lib/src/test/default-config.spec.ts
+++ b/projects/ngx-mask-lib/src/test/default-config.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { TestMaskComponent } from './utils/test-component.component';
+import { provideEnvironmentNgxMask } from '../lib/ngx-mask.providers';
+import { NgxMaskDirective } from '../lib/ngx-mask.directive';
+import { optionsConfig } from '../lib/ngx-mask.config';
+
+function createComponentWithDefaultConfig(
+    defaultConfig?: optionsConfig
+): ComponentFixture<TestMaskComponent> {
+    TestBed.configureTestingModule({
+        declarations: [TestMaskComponent],
+        imports: [ReactiveFormsModule, NgxMaskDirective],
+        providers: [provideEnvironmentNgxMask(defaultConfig)],
+    });
+    const fixture = TestBed.createComponent(TestMaskComponent);
+    return fixture;
+}
+
+describe('Default config', () => {
+    it('default config - decimalMarker and thousandSeparator', () => {
+        const fixture = createComponentWithDefaultConfig({
+            decimalMarker: ',',
+            thousandSeparator: '.',
+        });
+        const component = fixture.componentInstance;
+        component.mask = 'separator';
+        component.form = new FormControl(1234.56);
+        fixture.detectChanges();
+        fixture.whenRenderingDone().then(() => {
+            expect(fixture.nativeElement.querySelector('input').value).toBe('1.234,56');
+        });
+    });
+
+    it('default config - decimalMarker and thousandSeparator', () => {
+        const fixture = createComponentWithDefaultConfig({
+            decimalMarker: '.',
+            thousandSeparator: ' ',
+        });
+        const component = fixture.componentInstance;
+        component.mask = 'separator';
+        component.form = new FormControl(1234.56);
+        fixture.detectChanges();
+        fixture.whenRenderingDone().then(() => {
+            expect(fixture.nativeElement.querySelector('input').value).toBe('1 234.56');
+        });
+    });
+
+    it('default config overriden - decimalMarker and thousandSeparator', () => {
+        const fixture = createComponentWithDefaultConfig({
+            decimalMarker: '.',
+            thousandSeparator: ' ',
+        });
+        const component = fixture.componentInstance;
+        component.mask = 'separator';
+        // Override default decimalMarker and thousandSeparator
+        component.decimalMarker = ',';
+        component.thousandSeparator = '.';
+        component.form = new FormControl(1234.56);
+        component.specialCharacters = ['/']; // Explicit set needed to prevent bug in ngx-mask.directive.ts OnChanges event (if specialCharacters is undefined, OnChanges function will return prematurely and won't apply provided thousandSeparator and decimalMarker)
+        fixture.detectChanges();
+        fixture.whenRenderingDone().then(() => {
+            expect(fixture.nativeElement.querySelector('input').value).toBe('1.234,56');
+        });
+    });
+});

--- a/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/test-component.component.ts
@@ -30,37 +30,37 @@ import { IConfig } from '../../lib/ngx-mask.config';
 export class TestMaskComponent {
     public mask!: string | undefined;
 
-    public form: FormControl = new FormControl(null);
+    public form: FormControl = new FormControl();
 
-    public dropSpecialCharacters: IConfig['dropSpecialCharacters'] = true;
+    public dropSpecialCharacters: IConfig['dropSpecialCharacters'] | undefined;
 
-    public clearIfNotMatch: IConfig['clearIfNotMatch'] = false;
+    public clearIfNotMatch: IConfig['clearIfNotMatch'] | undefined;
 
-    public patterns!: IConfig['patterns'];
+    public patterns: IConfig['patterns'] | undefined;
 
     public prefix: IConfig['prefix'] = '';
 
-    public thousandSeparator: IConfig['thousandSeparator'] = ' ';
+    public thousandSeparator: IConfig['thousandSeparator'] | undefined;
 
-    public decimalMarker: IConfig['decimalMarker'] = ',';
+    public decimalMarker: IConfig['decimalMarker'] | undefined;
 
     public suffix: IConfig['suffix'] = '';
 
-    public specialCharacters!: IConfig['specialCharacters'];
+    public specialCharacters: IConfig['specialCharacters'] | undefined;
 
-    public showMaskTyped: IConfig['showMaskTyped'] = false;
+    public showMaskTyped: IConfig['showMaskTyped'] | undefined;
 
-    public placeHolderCharacter: IConfig['placeHolderCharacter'] = '_';
+    public placeHolderCharacter: IConfig['placeHolderCharacter'] | undefined;
 
-    public hiddenInput: IConfig['hiddenInput'] = false;
+    public hiddenInput: IConfig['hiddenInput'] | undefined;
 
     public separatorLimit: IConfig['separatorLimit'] = '';
 
-    public allowNegativeNumbers: IConfig['allowNegativeNumbers'] = false;
+    public allowNegativeNumbers: IConfig['allowNegativeNumbers'] | undefined;
 
-    public leadZeroDateTime: IConfig['leadZeroDateTime'] = false;
+    public leadZeroDateTime: IConfig['leadZeroDateTime'] | undefined;
 
-    public triggerOnMaskChange: IConfig['triggerOnMaskChange'] = false;
+    public triggerOnMaskChange: IConfig['triggerOnMaskChange'] | undefined;
 
     public cdr = inject(ChangeDetectorRef);
 }


### PR DESCRIPTION
## PR Checklist

- [X ] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: 1066

If we set decimalMarker: "," in provideEnvironmentNgxMask(config) in app.module.ts, initial decimal number won't format correctly in input field (eg. 12.34 will appear as 1234). However, it will be formatted correctly if we explicitely define <input decimalMarker="," ...>.

Reproduction:
https://stackblitz.com/edit/angular-13-zhsicj?file=src%2Fapp%2Fapp.module.ts,src%2Fapp%2Fapp.component.html

First input field relies on config options provided in module.app.ts and is not displayed correctly:

provideEnvironmentNgxMask({
      decimalMarker: ',',
      thousandSeparator: '.',
    })
Second input explicitely defines: <input decimalMarker="," thousandSeparator="." ... /> and is displayed correctly.

I think this issue started from version 15. It worked with <15 when default config was set as NgxMaskModule.forRoot(maskConfig)

## What is the new behavior?

PR fixes this issue, so if we define decimalMarker and thousandSeparator in default config in `provideEnvironmentNgxMask()`, initial value will be formatted correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No

## Other information

Minor fix was made in `ngx-mask.directive.ts` (actually only decimalMarker is problematic and was fixed, thousandSeparator is working ok).

New unit test file was created (`default-config.spec.ts`) that tests this issue (tests that provideEnvironmentNgxMask() is respected, and also a test that overriding default config with explicitely defined decimalMarker prop in the component instance is also working as expected).

Note that the existing `TestMaskComponent` (in `test/utils/test-component.component.ts`) had to be little changed in order to make test of default config. Default values in TestMaskComponent's properties had to be replaced with `undefined` value, because otherwise default config will not be used. Actually for this bug only decimalMarker property is relevant and could be set to undefined, but probably better to fix all other props. However some props caused issues if set to undefined (those are: prefix, suffix, specialCharacters) - they are still set to '' by default. The changes in TestMaskComponent do not impact other unit test (they still all pass).
