### PR TITLE
fix custom drop special characters on validation

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
@@ -661,6 +661,14 @@ export class NgxMaskApplierService {
         return res;
     }
 
+    public _findDropSpecialChar(inputSymbol: string): undefined | string {
+        if (Array.isArray(this.dropSpecialCharacters)) {
+            return this.dropSpecialCharacters.find((val: string) => val === inputSymbol);
+        }
+
+        return this._findSpecialChar(inputSymbol);
+    }
+
     public _findSpecialChar(inputSymbol: string): undefined | string {
         return this.specialCharacters.find((val: string) => val === inputSymbol);
     }

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -336,7 +336,7 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
                 const array = this._maskValue.split('*');
                 const length: number = this._maskService.dropSpecialCharacters
                     ? this._maskValue.length -
-                      this._maskService.checkSpecialCharAmount(this._maskValue) -
+                      this._maskService.checkDropSpecialCharAmount(this._maskValue) -
                       counterOfOpt
                     : this.prefix
                     ? this._maskValue.length + this.prefix.length - counterOfOpt

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -394,10 +394,11 @@ export class NgxMaskService extends NgxMaskApplierService {
         );
     }
 
-    public checkSpecialCharAmount(mask: string): number {
+    public checkDropSpecialCharAmount(mask: string): number {
         const chars: string[] = mask
             .split(MaskExpression.EMPTY_STRING)
-            .filter((item: string) => this._findSpecialChar(item));
+            .filter((item: string) => this._findDropSpecialChar(item));
+
         return chars.length;
     }
 

--- a/projects/ngx-mask-lib/src/test/validation.spec.ts
+++ b/projects/ngx-mask-lib/src/test/validation.spec.ts
@@ -67,6 +67,25 @@ export class TestValidatorNumber {
     public validate = true;
 }
 
+@Component({
+    selector: 'jsdaddy-open-source-test',
+    template: `
+        <input
+            id="maska"
+            [mask]="mask"
+            [specialCharacters]="specialCharacters"
+            [dropSpecialCharacters]="dropSpecialCharacters"
+            [formControl]="form" />
+    `,
+})
+// eslint-disable-next-line @angular-eslint/component-class-suffix
+export class TestValidatorDropSpecialCharacters {
+    public form: FormControl = new FormControl('+373', Validators.required);
+    public mask = '+000';
+    public specialCharacters = ['+', ' '];
+    public dropSpecialCharacters = [' '];
+}
+
 describe('Directive: Mask (Validation)', () => {
     describe('Global validation true, validation attribute on input not specified', () => {
         let fixture: ComponentFixture<TestMaskNoValidationAttributeComponent>;
@@ -364,6 +383,42 @@ describe('Directive: Mask (Validation)', () => {
             equal('444.31', '444.31', fixture);
             expect(component.form.valid).toBe(true);
             expect(component.form.value).toBe(44431);
+        });
+    });
+
+    describe('Global validation true, dropSpecialCharacters attribute on input specified as array', () => {
+        let fixture: ComponentFixture<TestValidatorDropSpecialCharacters>;
+        let component: TestValidatorDropSpecialCharacters;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestValidatorDropSpecialCharacters],
+                imports: [ReactiveFormsModule, NgxMaskDirective],
+                providers: [provideNgxMask({ validation: true })],
+            });
+            fixture = TestBed.createComponent(TestValidatorDropSpecialCharacters);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+        });
+
+        it('dropSpecialCharacters is different from specialCharacters', () => {
+            component.mask = '+000';
+            component.specialCharacters = ['+', ' '];
+            component.dropSpecialCharacters = [' '];
+
+            equal('+37', '+37', fixture);
+            expect(component.form.valid).toBe(false);
+
+            equal('+373', '+373', fixture);
+            expect(component.form.valid).toBe(true);
+
+            component.mask = '+000 000 00 000';
+
+            equal('+3736000000', '+373 600 00 00', fixture);
+            expect(component.form.valid).toBe(false);
+
+            equal('+37360000000', '+373 600 00 000', fixture);
+            expect(component.form.valid).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

when drop special characters is different from special characters the validation does not always work

example
mask: `+000`
specialCharacters: `['+', ' ']`
dorpSpecialCharacters: `[' ']`
value: `+37`

when the validation is done, it checks if dropSpecialCharacters is set, but when removing the characters from the value, it removed those from specialCharacters, and therefore the validation was not correct

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No

## Other information
