### PR TITLE
fix(ref: #1410): fix deleting selected text before special character

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -117,11 +117,16 @@ export class NgxMaskService extends NgxMaskApplierService {
         if (justPasted && (this.hiddenInput || !this.hiddenInput)) {
             newInputValue = inputValue;
         }
+        const isNoSelectionBeforeSpecialCharacter =
+            typeof this.selStart === "number" &&
+            typeof this.selEnd === "number" &&
+            this.selStart + 1 === this.selEnd;
         if (
             backspaced &&
             this.specialCharacters.indexOf(
                 this.maskExpression[position] ?? MaskExpression.EMPTY_STRING
             ) !== -1 &&
+            isNoSelectionBeforeSpecialCharacter &&
             this.showMaskTyped &&
             !this.prefix
         ) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
https://github.com/JsDaddy/ngx-mask/issues/1410
When changing the value in the input, according to the stack below, the problem is in the applyMask function. 
<img width="513" alt="ngx-mask-callstack" src="https://github.com/user-attachments/assets/316313c3-d524-4d45-9aef-f13eeee8ea81">


In this function, one of the "if" blocks checks:
- the current key is Backspace
- the caret is on a special character (such as : /)
- it is necessary to show the mask type on the input
- no prefix

When the conditions of the if block are met, the new input value will remain the same, i.e. the current value will be written to it. This is implemented for an obvious reason, so that the user cannot delete a special character.

When selecting text before a special character and pressing the Backspace key, this logic above still works, because the caret is after the special character, there is no check that the text we want to delete is selected further.

## What is the new behavior?
I added such a check, I saw that the class `NgxMaskService` has fields that monitor text selection - `selStart` and `selEnd`. If the difference between them is 1, then the text is not selected and does not need to be deleted, otherwise the selected text will be deleted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
