### PR TITLE
Changing hidden input breaks the entered value again #1449

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.config.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.config.ts
@@ -17,7 +17,7 @@ export type NgxMaskConfig = {
     shownMaskExpression: string;
     specialCharacters: string[] | readonly string[];
     dropSpecialCharacters: boolean | string[] | readonly string[];
-    hiddenInput: boolean | null;
+    hiddenInput: boolean;
     validation: boolean;
     separatorLimit: string;
     apm: boolean;
@@ -54,7 +54,7 @@ export const initialConfig: NgxMaskConfig = {
     showMaskTyped: false,
     placeHolderCharacter: '_',
     dropSpecialCharacters: true,
-    hiddenInput: null,
+    hiddenInput: false,
     shownMaskExpression: '',
     separatorLimit: '',
     allowNegativeNumbers: false,

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -1147,11 +1147,12 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
                                 : expression;
                 }
             } else {
+                const cleanMask = this._maskService.removeMask(mask);
                 const check: boolean = this._maskService
                     .removeMask(this._inputValue)
                     ?.split(MaskExpression.EMPTY_STRING)
                     .every((character, index) => {
-                        const indexMask = mask.charAt(index);
+                        const indexMask = cleanMask.charAt(index);
                         return this._maskService._checkSymbolMask(character, indexMask);
                     });
 

--- a/projects/ngx-mask-lib/src/test/add-prefix.spec.ts
+++ b/projects/ngx-mask-lib/src/test/add-prefix.spec.ts
@@ -2,7 +2,7 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal } from './utils/test-functions.component';
+import { equal, Paste } from './utils/test-functions.component';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 
@@ -40,18 +40,18 @@ describe('Directive: Mask (Add prefix)', () => {
         equal('123456789', '+55 (12) 3456-789_', fixture);
         equal('1234567890', '+55 (12) 3456-7890', fixture);
         equal('12345678901', '+55 (12) 3 4567-8901', fixture);
-        equal('+55 (1', '+55 (1_) ____-____', fixture);
-        equal('+55 (12', '+55 (12) ____-____', fixture);
-        equal('+55 (12)', '+55 (12) ____-____', fixture);
-        equal('+55 (12) 3', '+55 (12) 3___-____', fixture);
-        equal('+55 (12) 34', '+55 (12) 34__-____', fixture);
-        equal('+55 (12) 345', '+55 (12) 345_-____', fixture);
-        equal('+55 (12) 3456', '+55 (12) 3456-____', fixture);
-        equal('+55 (12) 3456-7', '+55 (12) 3456-7___', fixture);
-        equal('+55 (12) 3456-78', '+55 (12) 3456-78__', fixture);
-        equal('+55 (12) 3456-789', '+55 (12) 3456-789_', fixture);
-        equal('+55 (12) 3456-7890', '+55 (12) 3456-7890', fixture);
-        equal('+55 (12) 3 4567-8901', '+55 (12) 3 4567-8901', fixture);
+        equal('+55 (1', '+55 (1_) ____-____', fixture, false, Paste);
+        equal('+55 (12', '+55 (12) ____-____', fixture, false, Paste);
+        equal('+55 (12)', '+55 (12) ____-____', fixture, false, Paste);
+        equal('+55 (12) 3', '+55 (12) 3___-____', fixture, false, Paste);
+        equal('+55 (12) 34', '+55 (12) 34__-____', fixture, false, Paste);
+        equal('+55 (12) 345', '+55 (12) 345_-____', fixture, false, Paste);
+        equal('+55 (12) 3456', '+55 (12) 3456-____', fixture, false, Paste);
+        equal('+55 (12) 3456-7', '+55 (12) 3456-7___', fixture, false, Paste);
+        equal('+55 (12) 3456-78', '+55 (12) 3456-78__', fixture, false, Paste);
+        equal('+55 (12) 3456-789', '+55 (12) 3456-789_', fixture, false, Paste);
+        equal('+55 (12) 3456-7890', '+55 (12) 3456-7890', fixture, false, Paste);
+        equal('+55 (12) 3 4567-8901', '+55 (12) 3 4567-8901', fixture, false, Paste);
     });
     it('dropSpecialCharacters false should return value with prefix', () => {
         component.mask = '00-000-000-00';
@@ -71,15 +71,15 @@ describe('Directive: Mask (Add prefix)', () => {
     it('should delete prefix in pasted content', () => {
         component.mask = 'AAA-AAA-AAA';
         component.prefix = 'FOO-';
-        equal('FOO-D', 'FOO-D', fixture);
-        equal('FOO-DD', 'FOO-DD', fixture);
-        equal('FOO-DDD', 'FOO-DDD', fixture);
-        equal('FOO-DDD-D', 'FOO-DDD-D', fixture);
-        equal('FOO-DDD-DD', 'FOO-DDD-DD', fixture);
-        equal('FOO-DDD-DDD', 'FOO-DDD-DDD', fixture);
-        equal('FOO-DDD-DDD-D', 'FOO-DDD-DDD-D', fixture);
-        equal('FOO-DDD-DDD-DD', 'FOO-DDD-DDD-DD', fixture);
-        equal('FOO-DDD-DDD-DDD', 'FOO-DDD-DDD-DDD', fixture);
+        equal('FOO-D', 'FOO-D', fixture, false, Paste);
+        equal('FOO-DD', 'FOO-DD', fixture, false, Paste);
+        equal('FOO-DDD', 'FOO-DDD', fixture, false, Paste);
+        equal('FOO-DDD-D', 'FOO-DDD-D', fixture, false, Paste);
+        equal('FOO-DDD-DD', 'FOO-DDD-DD', fixture, false, Paste);
+        equal('FOO-DDD-DDD', 'FOO-DDD-DDD', fixture, false, Paste);
+        equal('FOO-DDD-DDD-D', 'FOO-DDD-DDD-D', fixture, false, Paste);
+        equal('FOO-DDD-DDD-DD', 'FOO-DDD-DDD-DD', fixture, false, Paste);
+        equal('FOO-DDD-DDD-DDD', 'FOO-DDD-DDD-DDD', fixture, false, Paste);
         expect(component.form.value).toEqual('DDDDDDDDD');
     });
 
@@ -87,15 +87,15 @@ describe('Directive: Mask (Add prefix)', () => {
         component.mask = 'AAA-AAA-AAA';
         component.prefix = 'FOO-';
         component.dropSpecialCharacters = false;
-        equal('FOO-S', 'FOO-S', fixture);
-        equal('FOO-SS', 'FOO-SS', fixture);
-        equal('FOO-SSS', 'FOO-SSS', fixture);
-        equal('FOO-SSS-S', 'FOO-SSS-S', fixture);
-        equal('FOO-SSS-SS', 'FOO-SSS-SS', fixture);
-        equal('FOO-SSS-SSS', 'FOO-SSS-SSS', fixture);
-        equal('FOO-SSS-SSS-S', 'FOO-SSS-SSS-S', fixture);
-        equal('FOO-SSS-SSS-SS', 'FOO-SSS-SSS-SS', fixture);
-        equal('FOO-SSS-SSS-SSS', 'FOO-SSS-SSS-SSS', fixture);
+        equal('FOO-S', 'FOO-S', fixture, false, Paste);
+        equal('FOO-SS', 'FOO-SS', fixture, false, Paste);
+        equal('FOO-SSS', 'FOO-SSS', fixture, false, Paste);
+        equal('FOO-SSS-S', 'FOO-SSS-S', fixture, false, Paste);
+        equal('FOO-SSS-SS', 'FOO-SSS-SS', fixture, false, Paste);
+        equal('FOO-SSS-SSS', 'FOO-SSS-SSS', fixture, false, Paste);
+        equal('FOO-SSS-SSS-S', 'FOO-SSS-SSS-S', fixture, false, Paste);
+        equal('FOO-SSS-SSS-SS', 'FOO-SSS-SSS-SS', fixture, false, Paste);
+        equal('FOO-SSS-SSS-SSS', 'FOO-SSS-SSS-SSS', fixture, false, Paste);
         expect(component.form.value).toEqual('FOO-SSS-SSS-SSS');
     });
 
@@ -144,21 +144,21 @@ describe('Directive: Mask (Add prefix)', () => {
         expect(component.form.value).toBe('KZ123 123');
     });
 
-    it('should remove prefix when setValue triggerOnMaskChange = false', () => {
+    it('should remove prefix when setValue triggerOnMaskChange = false & dropSpecialCharacters = true', () => {
         component.mask = '000 000';
         component.prefix = 'KZ';
         component.dropSpecialCharacters = true;
         component.form.setValue('KZ123123');
         equal('KZ123123', 'KZ123 123', fixture);
-        expect(component.form.value).toBe('KZ123123');
+        expect(component.form.value).toBe('123123');
     });
 
-    it('should remove prefix when setValue triggerOnMaskChange = false', () => {
+    it('should remove prefix when setValue triggerOnMaskChange = false & dropSpecialCharacters = false', () => {
         component.mask = '000 000';
         component.prefix = 'KZ';
         component.dropSpecialCharacters = false;
         component.form.setValue('KZ123123');
         equal('KZ123123', 'KZ123 123', fixture);
-        expect(component.form.value).toBe('KZ123123');
+        expect(component.form.value).toBe('KZ123 123');
     });
 });

--- a/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal, typeTest } from './utils/test-functions.component';
+import { equal, Paste, pasteTest } from './utils/test-functions.component';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 
@@ -110,7 +110,7 @@ describe('Directive: Mask', () => {
 
     it('Masks with numbers, strings e special characters', () => {
         component.mask = '(099) A99-SSSS';
-        equal('as', '(', fixture);
+        equal('as', '(', fixture, false, Paste);
         equal('(1', '(1', fixture);
         equal('(12', '(12', fixture);
         equal('(123', '(123', fixture);
@@ -339,7 +339,7 @@ describe('Directive: Mask', () => {
 
     it('should strip special characters from form control value', () => {
         component.mask = '00/00/0000';
-        typeTest('30/08/19921', fixture);
+        pasteTest('30/08/19921', fixture);
         expect(component.form.value).toBe('30081992');
     });
 
@@ -368,9 +368,9 @@ describe('Directive: Mask', () => {
             },
         };
         equal('', '', fixture);
-        equal('2578989', '[', fixture);
+        equal('2578989', '[', fixture, false, Paste);
         equal('hello world', '[hel]-[low]*[or]', fixture);
-        equal('111.111-11', '[', fixture);
+        equal('111.111-11', '[', fixture, false, Paste);
 
         component.mask = '(000-000)';
         component.specialCharacters = ['(', '-', ')'];
@@ -496,7 +496,7 @@ describe('Directive: Mask', () => {
         component.mask = '(000) 000-00-00';
         fixture.detectChanges();
         equal('0', '(0', fixture);
-        equal('(', '(', fixture);
+        equal('(', '(', fixture, false, Paste);
         const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
         const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
         debugElement.triggerEventHandler('keydown', {
@@ -504,7 +504,9 @@ describe('Directive: Mask', () => {
             keyCode: 8,
             target: inputTarget,
         });
-        equal('(', '', fixture);
+        debugElement.triggerEventHandler('input', { target: inputTarget });
+        debugElement.triggerEventHandler('ngModelChange', { target: inputTarget });
+        expect(inputTarget.value).toBe('');
     });
 
     it('should remove ghost character on toggling mask', () => {
@@ -941,7 +943,7 @@ describe('Directive: Mask', () => {
         component.showMaskTyped = true;
         component.keepCharacterPositions = true;
 
-        equal('11/11/1111', '11/11/1111', fixture);
+        equal('11111111', '11/11/1111', fixture, false, Paste);
         component.form.setValue('22/22/2222');
         fixture.detectChanges();
         requestAnimationFrame(() => {

--- a/projects/ngx-mask-lib/src/test/delete.spec.ts
+++ b/projects/ngx-mask-lib/src/test/delete.spec.ts
@@ -5,7 +5,6 @@ import type { DebugElement } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal } from './utils/test-functions.component';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 
@@ -86,8 +85,9 @@ describe('Directive: Mask (Delete)', () => {
             target: inputTarget,
         });
         debugElement.triggerEventHandler('input', { target: inputTarget });
+        debugElement.triggerEventHandler('ngModelChange', { target: inputTarget });
 
-        equal(inputTarget.value, '***/*5/6789', fixture);
+        expect(inputTarget.value).toEqual('***/*5/6789');
         expect(inputTarget.selectionStart).toEqual(6);
     });
 

--- a/projects/ngx-mask-lib/src/test/dynamic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/dynamic.spec.ts
@@ -221,7 +221,7 @@ describe('Directive: Mask (Dynamic)', () => {
         expect(component.form.valid).toBeFalse();
         equal('A0', 'A0', fixture);
         expect(component.form.valid).toBeFalse();
-        equal('A00', 'A00', fixture);
+        equal('A00', 'A0 0', fixture);
         expect(component.form.valid).toBeFalse();
         equal('AAA0DD', 'AAA 0DD', fixture);
         expect(component.form.valid).toBeTrue();

--- a/projects/ngx-mask-lib/src/test/secure-mask.spec.ts
+++ b/projects/ngx-mask-lib/src/test/secure-mask.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal, typeTest } from './utils/test-functions.component';
+import { equal, typeTest, pasteTest, Paste } from './utils/test-functions.component';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 import type { DebugElement } from '@angular/core';
@@ -69,7 +69,7 @@ describe('Directive: Mask (Secure)', () => {
     it('it checks secure input functionality on reset', () => {
         component.mask = 'XXX/X0/0000';
         component.hiddenInput = true;
-        typeTest('54321', fixture);
+        pasteTest('54321', fixture);
         component.form.reset('98765');
         fixture.whenStable().then(() => {
             expect(fixture.nativeElement.querySelector('input').value).toBe('***/*5');
@@ -79,7 +79,7 @@ describe('Directive: Mask (Secure)', () => {
     it('it checks secure input functionality on reset then typed', () => {
         component.mask = 'XXX/X0/0000';
         component.hiddenInput = true;
-        typeTest('54321', fixture);
+        pasteTest('54321', fixture);
         component.form.reset();
         equal('98765', '***/*5', fixture);
     });
@@ -87,7 +87,7 @@ describe('Directive: Mask (Secure)', () => {
     it('it checks secure input functionality on setValue(longer string)', () => {
         component.mask = 'XXX/X0/0000';
         component.hiddenInput = true;
-        typeTest('54321', fixture);
+        pasteTest('54321', fixture);
         component.form.setValue('1234567');
         fixture.whenStable().then(() => {
             expect(fixture.nativeElement.querySelector('input').value).toBe('***/*5/67');
@@ -106,7 +106,7 @@ describe('Directive: Mask (Secure)', () => {
         fixture.detectChanges();
         expect(component.form.dirty).toBeTruthy();
         expect(component.form.pristine).toBeFalsy();
-        fixture.whenStable().then(() => {
+        return fixture.whenStable().then(() => {
             expect(fixture.nativeElement.querySelector('input').value).toBe('123/45/6789');
         });
     });
@@ -133,7 +133,7 @@ describe('Directive: Mask (Secure)', () => {
         component.hiddenInput = true;
         component.mask = 'XXX/X0/0000';
         equal('54321', '***/*1', fixture);
-        typeTest('1', fixture);
+        pasteTest('1', fixture);
         expect(component.form.value).toBe('1');
         component.form.reset();
         expect(component.form.value).toBe(null);
@@ -207,7 +207,7 @@ describe('Directive: Mask (Secure)', () => {
         equal('1234', '***-*', fixture);
         fixture.detectChanges();
         component.hiddenInput = false;
-        equal(inputTarget.value, '123-4', fixture, true);
+        equal(inputTarget.value, '123-4', fixture, true, Paste);
     });
 
     it('change hiddenInput to false ', async () => {
@@ -224,17 +224,15 @@ describe('Directive: Mask (Secure)', () => {
     });
 
     it('change hiddenInput to false when mask is full', async () => {
-        const debug: DebugElement = fixture.debugElement.query(By.css('input'));
-        const inputTarget: HTMLInputElement = debug.nativeElement as HTMLInputElement;
-        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
-        fixture.detectChanges();
         component.mask = 'XXX/XX/XXXX';
         component.hiddenInput = true;
-        equal('123456789', '***/**/****', fixture);
-        expect(component.form.value).toBe('123456789');
+        fixture.detectChanges();
+        typeTest('123456789', fixture);
         fixture.detectChanges();
         component.hiddenInput = false;
-        equal(inputTarget.value, '123/45/6789', fixture, true);
-        expect(component.form.value).toBe('123456789');
+        fixture.detectChanges();
+        return fixture.whenStable().then(() => {
+            expect(fixture.nativeElement.querySelector('input').value).toBe('123/45/6789');
+        });
     });
 });

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import type { DebugElement } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal, typeTest } from './utils/test-functions.component';
+import { equal, Paste, typeTest } from './utils/test-functions.component';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 import { initialConfig } from 'ngx-mask';
@@ -114,7 +114,7 @@ describe('Separator: Mask', () => {
 
     it('separator precision 0 for 1000000.00', () => {
         component.mask = 'separator.0';
-        equal('1000000.00', '1 000 000', fixture);
+        equal('1000000.00', '1 000 000', fixture, false, Paste);
     });
 
     it('separator precision 2 with 0 after point for 1000000.00', () => {
@@ -201,7 +201,7 @@ describe('Separator: Mask', () => {
     it('separator thousandSeparator . precision 0 for 1000000.00', () => {
         component.mask = 'separator.0';
         component.thousandSeparator = '.';
-        equal('1000000,00', '1.000.000', fixture);
+        equal('1000000,00', '1.000.000', fixture, false, Paste);
     });
 
     it('separator thousandSeparator , for 1000000', () => {
@@ -225,7 +225,7 @@ describe('Separator: Mask', () => {
     it('separator thousandSeparator , precision 0 for 1000000.00', () => {
         component.mask = 'separator.0';
         component.thousandSeparator = ',';
-        equal('1000000.00', '1,000,000', fixture);
+        equal('1000000.00', '1,000,000', fixture, false, Paste);
     });
 
     it(`separator thousandSeparator ' for 1000000`, () => {
@@ -249,7 +249,7 @@ describe('Separator: Mask', () => {
     it(`separator thousandSeparator ' precision 0 for 1000000.00`, () => {
         component.mask = 'separator.0';
         component.thousandSeparator = `'`;
-        equal('1000000.00', `1'000'000`, fixture);
+        equal('1000000.00', `1'000'000`, fixture, false, Paste);
     });
 
     it('should not shift cursor for input in-between digits', () => {

--- a/projects/ngx-mask-lib/src/test/show-mask-typed.spec.ts
+++ b/projects/ngx-mask-lib/src/test/show-mask-typed.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal } from './utils/test-functions.component';
+import { equal, Paste } from './utils/test-functions.component';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 import type { DebugElement } from '@angular/core';
@@ -193,9 +193,9 @@ describe('Directive: Mask', () => {
         spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
         fixture.detectChanges();
 
-        equal('+38 1', '+38 1', fixture);
-        equal('+38 12', '+38 12', fixture);
-        equal('+38 123', '+38 123', fixture);
+        equal('+38 1', '+38 1', fixture, false, Paste);
+        equal('+38 12', '+38 12', fixture, false, Paste);
+        equal('+38 123', '+38 123', fixture, false, Paste);
         expect(inputTarget.selectionStart).toBe(7);
         component.showMaskTyped = true;
         inputTarget.focus();

--- a/projects/ngx-mask-lib/src/test/time-mask.spec.ts
+++ b/projects/ngx-mask-lib/src/test/time-mask.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TestMaskComponent } from './utils/test-component.component';
-import { equal } from './utils/test-functions.component';
+import { equal, Paste } from './utils/test-functions.component';
 import { provideNgxMask } from '../lib/ngx-mask.providers';
 import { NgxMaskDirective } from '../lib/ngx-mask.directive';
 
@@ -45,7 +45,8 @@ describe('Directive: Mask (Time)', () => {
     it('Hours', () => {
         component.showMaskTyped = true;
         component.mask = 'Hh:m0';
-        equal('3__:__', '3_:__', fixture);
+        equal('3__:__', '3_:__', fixture, false, Paste);
+        equal('3__:__', '3:__', fixture);
         equal('33:__', '3:3_', fixture);
         equal('33__:__', '3:3_', fixture);
     });
@@ -207,30 +208,30 @@ describe('Directive: Mask (Time)', () => {
 
     it('Date (d0/M0:0000', () => {
         component.mask = 'd0/M0:0000';
-        equal('999999', '9/9:9999', fixture);
-        equal('888888', '8/8:8888', fixture);
-        equal('777777', '7/7:7777', fixture);
-        equal('666666', '6/6:6666', fixture);
-        equal('555555', '5/5:5555', fixture);
-        equal('444444', '4/4:4444', fixture);
-        equal('333333', '3/3:3333', fixture);
-        equal('2222222', '22/2:2222', fixture);
-        equal('11111111', '11/11:1111', fixture);
-        equal('20232023', '20/2:3202', fixture);
+        equal('999999', '9/9:9999', fixture, false, Paste);
+        equal('888888', '8/8:8888', fixture, false, Paste);
+        equal('777777', '7/7:7777', fixture, false, Paste);
+        equal('666666', '6/6:6666', fixture, false, Paste);
+        equal('555555', '5/5:5555', fixture, false, Paste);
+        equal('444444', '4/4:4444', fixture, false, Paste);
+        equal('333333', '3/3:3333', fixture, false, Paste);
+        equal('2222222', '22/2:2222', fixture, false, Paste);
+        equal('11111111', '11/11:1111', fixture, false, Paste);
+        equal('20232023', '20/2:3202', fixture, false, Paste);
     });
 
     it('Date (m0/d0/0000', () => {
         component.mask = 'm0/d0/0000';
-        equal('999999', '9/9/9999', fixture);
-        equal('888888', '8/8/8888', fixture);
-        equal('777777', '7/7/7777', fixture);
-        equal('666666', '6/6/6666', fixture);
-        equal('5555555', '55/5/5555', fixture);
-        equal('4444444', '44/4/4444', fixture);
-        equal('3333333', '33/3/3333', fixture);
-        equal('22222222', '22/22/2222', fixture);
-        equal('11111111', '11/11/1111', fixture);
-        equal('20232023', '20/2/3202', fixture);
+        equal('999999', '9/9/9999', fixture, false, Paste);
+        equal('888888', '8/8/8888', fixture, false, Paste);
+        equal('777777', '7/7/7777', fixture, false, Paste);
+        equal('666666', '6/6/6666', fixture, false, Paste);
+        equal('5555555', '55/5/5555', fixture, false, Paste);
+        equal('4444444', '44/4/4444', fixture, false, Paste);
+        equal('3333333', '33/3/3333', fixture, false, Paste);
+        equal('22222222', '22/22/2222', fixture, false, Paste);
+        equal('11111111', '11/11/1111', fixture, false, Paste);
+        equal('20232023', '20/2/3202', fixture, false, Paste);
     });
 
     it('Date (0000-M0-d0', () => {
@@ -441,7 +442,7 @@ describe('Directive: Mask (Time)', () => {
         equal('20231031', '2023.10.31', fixture);
     });
 
-    it('Date (0000.M0.d0 leadZero and showMaskTyped', () => {
+    it('Date (M0/d0/0000 leadZero and showMaskTyped', () => {
         component.mask = 'M0/d0/0000';
         component.leadZeroDateTime = true;
         component.showMaskTyped = true;
@@ -452,7 +453,7 @@ describe('Directive: Mask (Time)', () => {
     });
 
     it('Date (d0/M0/0000 leadZero)', () => {
-        component.mask = 'M0/d0/0000';
+        component.mask = 'd0/M0/0000';
         component.leadZeroDateTime = true;
         equal('4122000', '04/12/2000', fixture);
         equal('442000', '04/04/2000', fixture);

--- a/projects/ngx-mask-lib/src/test/utils/test-functions.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/test-functions.component.ts
@@ -1,16 +1,50 @@
-export function typeTest(inputValue: string, fixture: any): string {
+export const Paste = 'Paste';
+export const Type = 'Type';
+
+export function pasteTest(inputValue: string, fixture: any): string {
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('input').value = inputValue;
 
+    fixture.nativeElement.querySelector('input').dispatchEvent(new Event('paste'));
     fixture.nativeElement.querySelector('input').dispatchEvent(new Event('input'));
+    fixture.nativeElement.querySelector('input').dispatchEvent(new Event('ngModelChange'));
 
-    fixture.detectChanges();
     return fixture.nativeElement.querySelector('input').value;
 }
 
-export function equal(value: string, expectedValue: string, fixture: any, async = false): void {
-    typeTest(value, fixture);
+export function typeTest(inputValue: string, fixture: any): string {
+    fixture.detectChanges();
+    const inputArray = inputValue.split('');
+    const inputElement = fixture.nativeElement.querySelector('input');
+
+    inputElement.value = '';
+    inputElement.dispatchEvent(new Event('input'));
+    inputElement.dispatchEvent(new Event('ngModelChange'));
+
+    {
+        for (const element of inputArray) {
+            inputElement.dispatchEvent(new Event('keydown'), { key: element });
+            inputElement.value += element;
+            inputElement.dispatchEvent(new Event('input'));
+            inputElement.dispatchEvent(new Event('ngModelChange'));
+        }
+    }
+    return inputElement.value;
+}
+
+export function equal(
+    value: string,
+    expectedValue: string,
+    fixture: any,
+    async = false,
+    testType: typeof Paste | typeof Type = Type
+): void {
+    if (testType === Paste) {
+        pasteTest(value, fixture);
+    } else {
+        typeTest(value, fixture);
+    }
 
     if (async) {
         Promise.resolve().then(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [X] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [X] Other... Please describe:
  - Updated Type Testing to mimic browser behavior (events) since the testing suite does not have a browser.
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1449 
## What is the new behavior?
While setting hiddenInput to null use to do the trick it doesn't anymore. And setting hiddenInput to `false` will clash with parameters of the ngx-mask. The updated testing reveals some of those issues and null checking hiddenInput doesn't fix them all. These changes do.

There is a new PasteTest function and new behavior for TypeTest. They mimic the events that would occur with a human using the ngx-mask input in a browser. This shows several breaking test cases and including the ones in secure-mask.spec.ts that should be broken with the changes in 18.0.1. I also updated some of the specs test cases to pass while keeping each test cases' intentions.

Now the code will check if there are `symbol_star`s (*) in the value to process the input back to its true value when hiddenInput is `false`.

I also fix a issue with inputs with multiple mask types and those masks have specialCharacters (UK POST - S0 0SS||SAA 0SS||SS0A 0SS). It wasn't selecting the correct mask type on typing. Demo here: https://stackblitz.com/edit/stackblitz-starters-n8bkaa?file=src%2Fmain.ts

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Please let me know if you have feedback or questions. 
