### PR TITLE
Fix swiss locale thousands separator issue

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.config.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.config.ts
@@ -59,7 +59,7 @@ export const initialConfig: NgxMaskConfig = {
     separatorLimit: '',
     allowNegativeNumbers: false,
     validation: true,
-    specialCharacters: ['-', '/', '(', ')', '.', ':', ' ', '+', ',', '@', '[', ']', '"', "'"],
+    specialCharacters: ['-', '/', '(', ')', '.', ':', ' ', '+', ',', '@', '[', ']', '"', "'", "\u2019"],
     leadZeroDateTime: false,
     apm: false,
     leadZero: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

When using a Swiss locale (eg. `en-CH`), the numbers are formatted using a right single quotation marks ([U+2019](https://www.compart.com/en/unicode/U+2019)) and not apostrophes (U+0027) for thousands separator on Chrome, leading to NaN values being emitted via ngModel.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Correct number values are emitted.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information