### PR TITLE
Fix #1508

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
@@ -46,9 +46,11 @@ export class NgxMaskApplierService {
 
     public apm: NgxMaskConfig['apm'] = this._config.apm;
 
-    public inputTransformFn: NgxMaskConfig['inputTransformFn'] = this._config.inputTransformFn;
+    public inputTransformFn: NgxMaskConfig['inputTransformFn'] | null =
+        this._config.inputTransformFn;
 
-    public outputTransformFn: NgxMaskConfig['outputTransformFn'] = this._config.outputTransformFn;
+    public outputTransformFn: NgxMaskConfig['outputTransformFn'] | null =
+        this._config.outputTransformFn;
 
     public keepCharacterPositions: NgxMaskConfig['keepCharacterPositions'] =
         this._config.keepCharacterPositions;

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -421,7 +421,10 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
             return;
         }
         const el: HTMLInputElement = e.target as HTMLInputElement;
-        const transformedValue = this._maskService.inputTransformFn(el.value);
+
+        const transformedValue = this._maskService.inputTransformFn
+            ? this._maskService.inputTransformFn(el.value)
+            : el.value;
 
         if (el.type !== 'number') {
             if (typeof transformedValue === 'string' || typeof transformedValue === 'number') {
@@ -1011,18 +1014,14 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
                     (this._maskService.prefix || this._maskService.showMaskTyped))
             ) {
                 // Let the service we know we are writing value so that triggering onChange function won't happen during applyMask
-                if (typeof inputTransformFn !== 'function') {
-                    this._maskService.writingValue = true;
-                }
+                this._maskService.writingValue = true;
 
                 this._maskService.formElementProperty = [
                     'value',
                     this._maskService.applyMask(inputValue, this._maskService.maskExpression),
                 ];
                 // Let the service know we've finished writing value
-                if (typeof inputTransformFn !== 'function') {
-                    this._maskService.writingValue = false;
-                }
+                this._maskService.writingValue = false;
             } else {
                 this._maskService.formElementProperty = ['value', inputValue];
             }

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -596,15 +596,16 @@ export class NgxMaskService extends NgxMaskApplierService {
      * @param inputValue the current form input value
      */
     private formControlResult(inputValue: string): void {
+        const outputTransformFn = this.outputTransformFn ? this.outputTransformFn : (v: any) => v;
         if (this.writingValue && !inputValue) {
-            this.onChange(this.outputTransformFn(null));
+            this.onChange(outputTransformFn(null));
             return;
         }
         if (this.writingValue || (!this.triggerOnMaskChange && this.maskChanged)) {
             // eslint-disable-next-line no-unused-expressions,@typescript-eslint/no-unused-expressions
             this.triggerOnMaskChange && this.maskChanged
                 ? this.onChange(
-                      this.outputTransformFn(
+                      outputTransformFn(
                           this._toNumber(
                               this._checkSymbols(this._removeSuffix(this._removePrefix(inputValue)))
                           )
@@ -617,7 +618,7 @@ export class NgxMaskService extends NgxMaskApplierService {
         }
         if (Array.isArray(this.dropSpecialCharacters)) {
             this.onChange(
-                this.outputTransformFn(
+                outputTransformFn(
                     this._toNumber(
                         this._checkSymbols(
                             this._removeMask(
@@ -633,14 +634,14 @@ export class NgxMaskService extends NgxMaskApplierService {
             (!this.dropSpecialCharacters && this.prefix === inputValue)
         ) {
             this.onChange(
-                this.outputTransformFn(
+                outputTransformFn(
                     this._toNumber(
                         this._checkSymbols(this._removeSuffix(this._removePrefix(inputValue)))
                     )
                 )
             );
         } else {
-            this.onChange(this.outputTransformFn(this._toNumber(inputValue)));
+            this.onChange(outputTransformFn(this._toNumber(inputValue)));
         }
     }
 

--- a/projects/ngx-mask-lib/src/test/emit-events.cy-spec.ts
+++ b/projects/ngx-mask-lib/src/test/emit-events.cy-spec.ts
@@ -113,4 +113,58 @@ describe('Directive: Mask (emit-events)', () => {
         cy.get('#masked').type('SS11111DDDD11').blur().should('have.value', 'SS111');
         cy.get('#pre').should('have.text', '6');
     });
+
+    it("inputTransformFn should not break if it's null", () => {
+        cy.mount(CypressTestMaskComponent, {
+            componentProperties: {
+                mask: signal('00000||00000-0000'),
+                inputTransformFn: signal(null),
+            },
+        });
+
+        cy.get('#masked').type('123456789').blur().should('have.value', '12345-6789');
+        cy.get('#pre').should('have.text', '10');
+    });
+
+    it('inputTransformFn should not change input form status', () => {
+        const date = new Date('12-12-2012 11:14:01');
+        cy.mount(CypressTestMaskComponent, {
+            componentProperties: {
+                mask: signal('Hh:m0'),
+                dropSpecialCharacters: signal(false),
+                inputTransformFn: signal((value: unknown): string => {
+                    if (typeof value !== 'object') {
+                        return String(value);
+                    }
+                    const date = new Date('12-12-2012 11:14:01');
+                    return `${String(date.getHours()).padStart(2, '0')}${String(
+                        date.getMinutes()
+                    ).padStart(2, '0')}`;
+                }),
+                outputTransformFn: signal((value: string | number | undefined | null) => {
+                    if (value) {
+                        const fetch = new Date('12-12-2012 11:14:01');
+                        const values = String(value).split(':');
+                        if (values.length >= 2) {
+                            const hour = Number(values[0]);
+                            const minuts = Number(values[1]);
+                            fetch.setHours(hour);
+                            fetch.setMinutes(minuts);
+                        }
+                        fetch.setSeconds(0);
+                        return fetch.toString();
+                    }
+                    return;
+                }),
+            },
+        })
+            .wait(10)
+            .then((wrapper) => {
+                wrapper.component.form.reset(date);
+            });
+
+        cy.get('#masked').should('have.value', '11:14');
+        cy.get('#pristine').should('have.text', 'true');
+        cy.get('#pre').should('have.text', '2');
+    });
 });

--- a/projects/ngx-mask-lib/src/test/utils/cypress-test-component.component.ts
+++ b/projects/ngx-mask-lib/src/test/utils/cypress-test-component.component.ts
@@ -31,10 +31,13 @@ import { toSignal } from '@angular/core/rxjs-interop';
             [patterns]="patterns()"
             [keepCharacterPositions]="keepCharacterPositions()"
             [separatorLimit]="separatorLimit()"
-            [hiddenInput]="hiddenInput()" />
+            [hiddenInput]="hiddenInput()"
+            [inputTransformFn]="inputTransformFn()"
+            [outputTransformFn]="outputTransformFn()" />
 
         <pre id="pre">{{ counter$() }}</pre>
         <pre id="pre1">{{ form.value }}</pre>
+        <pre id="pristine">{{ form.pristine }}</pre>
         <div>
             {{ leadZeroDateTime() }}
         </div>
@@ -87,6 +90,14 @@ export class CypressTestMaskComponent {
 
     public specialCharacters = input<NgxMaskConfig['specialCharacters']>(
         this._config.specialCharacters
+    );
+
+    public inputTransformFn = input<NgxMaskConfig['inputTransformFn'] | null>(
+        this._config.inputTransformFn
+    );
+
+    public outputTransformFn = input<NgxMaskConfig['outputTransformFn'] | null>(
+        this._config.outputTransformFn
     );
 
     public form: FormControl = new FormControl('');


### PR DESCRIPTION
Handle null inputTransformFn and outputTransformFn in ngx-mask service.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1508

## What is the new behavior?

inputTransformFn/outputTransformFn and be set null. InputTransformFn no longer marks inputs as dirty on display value change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No