### PR TITLE
fix(forms): Propagate masked value to form control value.

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -927,7 +927,7 @@ export class NgxMaskDirective implements ControlValueAccessor, OnChanges, Valida
     /** It writes the value in the input */
     public async writeValue(controlValue: unknown): Promise<void> {
         let value = controlValue;
-        const inputTransformFn = this.inputTransformFn();
+        const inputTransformFn = this._maskService.inputTransformFn;
         if (typeof value === 'object' && value !== null && 'value' in value) {
             if ('disable' in value) {
                 this.setDisabledState(Boolean(value.disable));

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -267,6 +267,7 @@ export class NgxMaskService extends NgxMaskApplierService {
             this.currentValue = result;
             this._emitValue =
                 this.previousValue !== this.currentValue ||
+                newInputValue !== this.currentValue ||
                 this.maskChanged ||
                 this.writingValue ||
                 (this.previousValue === this.currentValue && justPasted);

--- a/projects/ngx-mask-lib/src/test/forms.spec.ts
+++ b/projects/ngx-mask-lib/src/test/forms.spec.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
+
+@Component({
+    selector: 'jsdaddy-open-source-test',
+    imports: [ReactiveFormsModule, NgxMaskDirective],
+    template: `<input mask="0000" [formControl]="form" />`,
+})
+class TestMaskComponent {
+    public form: FormControl = new FormControl('');
+}
+
+describe('Directive: Forms', () => {
+    let fixture: ComponentFixture<TestMaskComponent>;
+    let component: TestMaskComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [NgxMaskDirective],
+            providers: [provideNgxMask()],
+        });
+        fixture = TestBed.createComponent(TestMaskComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should propagate masked value to the form control value', () => {
+        component.form.setValue('A1234Z');
+        expect(component.form.value).toBe('1234');
+    });
+
+    it('should propagate masked value to the form control valueChanges observable', () => {
+        component.form.valueChanges.subscribe((newValue) => {
+            expect(newValue).toEqual('1234');
+        });
+
+        component.form.setValue('A1234Z');
+    });
+});

--- a/projects/ngx-mask-lib/src/test/forms.spec.ts
+++ b/projects/ngx-mask-lib/src/test/forms.spec.ts
@@ -39,4 +39,53 @@ describe('Directive: Forms', () => {
 
         component.form.setValue('A1234Z');
     });
+
+    it('should mask values when multiple calls to setValue() are made', () => {
+        component.form.setValue('A1234Z');
+        expect(component.form.value).toBe('1234');
+        component.form.setValue('A1234Z');
+        expect(component.form.value).toBe('1234');
+        component.form.setValue('A1234Z');
+        expect(component.form.value).toBe('1234');
+    });
+
+    it('should propagate masked value to the form control valueChanges observable when multiple calls to setValue() are made', () => {
+        component.form.valueChanges.subscribe((newValue) => {
+            expect(newValue).toEqual('1234');
+        });
+
+        component.form.setValue('A1234Z');
+        component.form.setValue('A1234Z');
+        component.form.setValue('A1234Z');
+    });
+
+    it('should not emit to valueChanges if the masked value has not changed with emitEvent: true', () => {
+        let emissionsToValueChanges = 0;
+
+        component.form.valueChanges.subscribe(() => {
+            emissionsToValueChanges++;
+        });
+
+        component.form.setValue('1234', { emitEvent: true });
+        component.form.setValue('1234', { emitEvent: true });
+
+        // Expect to emit 3 times, once for the first setValue() call, once by ngx-mask, and once for the second setValue() call.
+        // There is not fourth emission for when ngx-mask masks the value for a second time.
+        expect(emissionsToValueChanges).toBe(3);
+    });
+
+    it('should not emit to valueChanges if the masked value has not changed with emitEvent: false', () => {
+        let emissionsToValueChanges = 0;
+
+        component.form.valueChanges.subscribe(() => {
+            emissionsToValueChanges++;
+        });
+
+        component.form.setValue('1234', { emitEvent: false });
+        component.form.setValue('1234', { emitEvent: false });
+
+        // Expect to only have emitted once, only by ngx-mask.
+        // There is no second emission for when ngx-mask masks the value for a second time.
+        expect(emissionsToValueChanges).toBe(1);
+    });
 });


### PR DESCRIPTION
Ensure that the masked value is propagated to the form control value when "inputTransformFn" is not an instance variable in the component.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
If:
- a form control is modified via FormControl#setValue(),
- the value is transformed with a mask, and
- the component doesn't have an inputTransformFn.

Then, the underlying form control's value isn't updated with the new masked value.

Example in v19.0.6: https://stackblitz.com/edit/stackblitz-starters-chv17voi?file=src%2Fmain.ts
Example in v8.2.0: https://stackblitz.com/edit/stackblitz-starters-qfw8fjzy?file=src%2Fmain.ts


Issue Number: N/A

## What is the new behavior?
Ensures that the masked value is propagated to the form control value.

Ensure that the masked value is propagated to the form control if setValue() is called multiple times with values that are subsequently masked. I found this issue and pushed the fix in a second commit since I believe the root cause is different. Though the fix is dependent on the fix in the first commit so I placed it in this PR. I'm happy to split out the PR though if needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
