### PR TITLE
fix(config): Ensure that "triggerOnMaskChange" and "shownMaskExpression" are received in "NgxMaskService" when provided through "provideNgxMask()".

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
@@ -55,6 +55,9 @@ export class NgxMaskApplierService {
 
     public instantPrefix: NgxMaskConfig['instantPrefix'] = this._config.instantPrefix;
 
+    public triggerOnMaskChange: NgxMaskConfig['triggerOnMaskChange'] =
+        this._config.triggerOnMaskChange;
+
     private _shift = new Set<number>();
 
     public plusOnePosition = false;
@@ -65,7 +68,8 @@ export class NgxMaskApplierService {
 
     public showKeepCharacterExp = '';
 
-    public shownMaskExpression = '';
+    public shownMaskExpression: NgxMaskConfig['shownMaskExpression'] =
+        this._config.shownMaskExpression;
 
     public deletedSpecialCharacter = false;
 

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -14,7 +14,6 @@ export class NgxMaskService extends NgxMaskApplierService {
     public selEnd: number | null = null;
     public maskChanged = false;
     public maskExpressionArray: string[] = [];
-    public triggerOnMaskChange = false;
     public previousValue = '';
     public currentValue = '';
     /**

--- a/projects/ngx-mask-lib/src/test/default-config.spec.ts
+++ b/projects/ngx-mask-lib/src/test/default-config.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { TestMaskComponent } from './utils/test-component.component';
 import { provideEnvironmentNgxMask, NgxMaskDirective } from 'ngx-mask';
 import type { NgxMaskOptions } from 'ngx-mask';
+import { By } from '@angular/platform-browser';
 
 function createComponentWithDefaultConfig(
     defaultConfig?: NgxMaskOptions
@@ -95,5 +96,53 @@ describe('Default config', () => {
         fixture.whenRenderingDone().then(() => {
             expect(fixture.nativeElement.querySelector('input').value).toBe('15 000,33 €');
         });
+    });
+
+    it('default config - triggerOnMaskChange', async () => {
+        const fixture = createComponentWithDefaultConfig({
+            triggerOnMaskChange: true,
+        });
+        const component = fixture.componentInstance;
+        component.mask.set('');
+        fixture.detectChanges();
+
+        component.form.setValue('7912345678');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        let inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('7912345678');
+        expect(component.form.value).toEqual('7912345678');
+
+        component.mask.set('00 000 00 00');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('79 123 45 67');
+        expect(component.form.value).toEqual('791234567');
+    });
+
+    it('default config overridden - triggerOnMaskChange', async () => {
+        const fixture = createComponentWithDefaultConfig({
+            triggerOnMaskChange: false,
+        });
+        const component = fixture.componentInstance;
+        // Override default triggerOnMaskChange
+        component.triggerOnMaskChange.set(true);
+        component.mask.set('');
+        fixture.detectChanges();
+
+        component.form.setValue('7912345678');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        let inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('7912345678');
+        expect(component.form.value).toEqual('7912345678');
+
+        component.mask.set('00 000 00 00');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('79 123 45 67');
+        expect(component.form.value).toEqual('791234567');
     });
 });

--- a/projects/ngx-mask-lib/src/test/provide-ngx-mask.spec.ts
+++ b/projects/ngx-mask-lib/src/test/provide-ngx-mask.spec.ts
@@ -1,0 +1,235 @@
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { TestMaskComponent } from './utils/test-component.component';
+import {
+    provideEnvironmentNgxMask,
+    NgxMaskDirective,
+    NgxMaskService,
+    NgxMaskConfig,
+} from 'ngx-mask';
+import type { NgxMaskOptions } from 'ngx-mask';
+import { Component, EventEmitter } from '@angular/core';
+
+function createComponentWithDefaultConfigAndSimpleInputs(
+    defaultConfig?: NgxMaskOptions
+): ComponentFixture<TestMaskSimpleInputsComponent> {
+    TestBed.configureTestingModule({
+        imports: [ReactiveFormsModule, NgxMaskDirective, TestMaskComponent],
+        providers: [provideEnvironmentNgxMask(defaultConfig)],
+    });
+    return TestBed.createComponent(TestMaskSimpleInputsComponent);
+}
+
+@Component({
+    selector: 'jsdaddy-open-source-test',
+    standalone: true,
+    imports: [ReactiveFormsModule, NgxMaskDirective],
+    template: `<input [mask]="mask" [formControl]="form" />`,
+})
+export class TestMaskSimpleInputsComponent {
+    public form: FormControl = new FormControl();
+    public mask?: string;
+}
+
+describe('provideNgxMask', () => {
+    it('config - suffix', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({
+            suffix: 'aaa',
+        });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.suffix).toBe('aaa');
+    });
+
+    it('config - prefix', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ prefix: 'bbb' });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.prefix).toBe('bbb');
+    });
+
+    it('config - thousandSeparator', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ thousandSeparator: '-' });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.thousandSeparator).toBe('-');
+    });
+
+    it('config - decimalMarker', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ decimalMarker: '.' });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.decimalMarker).toBe('.');
+    });
+
+    it('config - clearIfNotMatch', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ clearIfNotMatch: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.clearIfNotMatch).toBeTrue();
+    });
+
+    it('config - showMaskTyped', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ showMaskTyped: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.showMaskTyped).toBeTrue();
+    });
+
+    it('config - placeHolderCharacter', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ placeHolderCharacter: 'ccc' });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.placeHolderCharacter).toBe('ccc');
+    });
+
+    it('config - shownMaskExpression', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({
+            shownMaskExpression: 'ddd',
+        });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.shownMaskExpression).toBe('ddd');
+    });
+
+    it('config - specialCharacters', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ specialCharacters: ['a'] });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.specialCharacters).toEqual(['a']);
+    });
+
+    it('config - dropSpecialCharacters', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ dropSpecialCharacters: ['a'] });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.dropSpecialCharacters).toEqual(['a']);
+    });
+
+    it('config - hiddenInput', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ hiddenInput: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.hiddenInput).toBeTrue();
+    });
+
+    it('config - validation', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ validation: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.validation).toBeTrue();
+    });
+
+    it('config - instantPrefix', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ instantPrefix: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.instantPrefix).toBeTrue();
+    });
+
+    it('config - separatorLimit', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ separatorLimit: 'a' });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.separatorLimit).toBe('a');
+    });
+
+    it('config - apm', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ apm: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.apm).toBeTrue();
+    });
+
+    it('config - allowNegativeNumbers', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ allowNegativeNumbers: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.allowNegativeNumbers).toBeTrue();
+    });
+
+    it('config - leadZeroDateTime', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ leadZeroDateTime: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.leadZeroDateTime).toBeTrue();
+    });
+
+    it('config - leadZero', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ leadZero: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.leadZero).toBeTrue();
+    });
+
+    it('config - triggerOnMaskChange', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ triggerOnMaskChange: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.triggerOnMaskChange).toBeTrue();
+    });
+
+    it('config - keepCharacterPositions', async () => {
+        createComponentWithDefaultConfigAndSimpleInputs({ keepCharacterPositions: true });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.keepCharacterPositions).toBeTrue();
+    });
+
+    it('config - inputTransformFn', async () => {
+        const mockInputTransformFn = () => 'test';
+        createComponentWithDefaultConfigAndSimpleInputs({
+            inputTransformFn: mockInputTransformFn,
+        });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.inputTransformFn).toBe(mockInputTransformFn);
+    });
+
+    it('config - outputTransformFn', async () => {
+        const mockOutputTransformFn = () => 'test';
+        createComponentWithDefaultConfigAndSimpleInputs({
+            outputTransformFn: mockOutputTransformFn,
+        });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.outputTransformFn).toBe(mockOutputTransformFn);
+    });
+
+    it('config - patterns', async () => {
+        const mockPatterns = {
+            '0': {
+                pattern: new RegExp('[a-zA-Z]'),
+            },
+        };
+        createComponentWithDefaultConfigAndSimpleInputs({
+            patterns: mockPatterns,
+        });
+        const service = TestBed.inject(NgxMaskService);
+        expect(service.patterns).toBe(mockPatterns);
+    });
+
+    it('config - all values', async () => {
+        const allConfigValues: NgxMaskConfig = {
+            suffix: 'aaa',
+            prefix: 'bbb',
+            thousandSeparator: ',',
+            decimalMarker: '.',
+            clearIfNotMatch: true,
+            showMaskTyped: true,
+            placeHolderCharacter: '_',
+            shownMaskExpression: 'c',
+            specialCharacters: ['d'],
+            dropSpecialCharacters: true,
+            hiddenInput: true,
+            validation: true,
+            instantPrefix: true,
+            separatorLimit: '1',
+            apm: true,
+            allowNegativeNumbers: true,
+            leadZeroDateTime: true,
+            leadZero: true,
+            triggerOnMaskChange: true,
+            keepCharacterPositions: true,
+            inputTransformFn: () => 'e',
+            outputTransformFn: () => 'f',
+            maskFilled: new EventEmitter<void>(),
+            patterns: {
+                '0': {
+                    pattern: new RegExp('[a-zA-Z]'),
+                },
+            },
+        };
+        createComponentWithDefaultConfigAndSimpleInputs(allConfigValues);
+        const service = TestBed.inject(NgxMaskService);
+
+        // Exclude the below config keys from the test which do not exist in the service or cannot be tested.
+        const excludeConfig = ['maskFilled'];
+
+        // Ensure that all provided config values are passed through to the service.
+        for (const key of Object.keys(allConfigValues)) {
+            if (!excludeConfig.includes(key)) {
+                expect((service as any)[key]).toEqual((allConfigValues as any)[key]);
+            }
+        }
+    });
+});

--- a/projects/ngx-mask-lib/src/test/trigger-on-mask-change.spec.ts
+++ b/projects/ngx-mask-lib/src/test/trigger-on-mask-change.spec.ts
@@ -1,9 +1,8 @@
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
-
 import { By } from '@angular/platform-browser';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TestMaskComponent } from './utils/test-component.component';
+import { ReactiveFormsModule } from '@angular/forms';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 import type { DebugElement } from '@angular/core';
 import { equal } from './utils/test-functions.component';
@@ -26,7 +25,7 @@ describe('Directive: Mask (Trigger on mask change)', () => {
         fixture.destroy();
     });
 
-    it('should trigger form value update if mask is changed', async () => {
+    it('should trigger form value update if mask is changed when triggerOnMaskChange is true', async () => {
         component.mask.set('');
         component.triggerOnMaskChange.set(true);
         fixture.detectChanges();
@@ -46,7 +45,27 @@ describe('Directive: Mask (Trigger on mask change)', () => {
         expect(component.form.value).toEqual('791234567');
     });
 
-    it('should trigger form value update if mask is changed', async () => {
+    it('should not trigger form value update if mask is changed when triggerOnMaskChange is false', async () => {
+        component.mask.set('');
+        component.triggerOnMaskChange.set(false);
+        fixture.detectChanges();
+
+        component.form.setValue('7912345678');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        let inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('7912345678');
+        expect(component.form.value).toEqual('7912345678');
+
+        component.mask.set('00 000 00 00');
+        fixture.detectChanges();
+        await fixture.whenStable();
+        inputEl = fixture.debugElement.query(By.css('input'));
+        expect(inputEl.nativeElement.value).toEqual('79 123 45 67');
+        expect(component.form.value).toEqual('7912345678');
+    });
+
+    it('should trigger form value update if mask is changed when triggerOnMaskChange is true', async () => {
         component.mask.set('00000||00000-0000');
         component.triggerOnMaskChange.set(true);
         const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
@@ -61,5 +80,22 @@ describe('Directive: Mask (Trigger on mask change)', () => {
         component.mask.set('S0S 0S0');
         equal(inputTarget.value, '', fixture, true);
         expect(component.form.value).toBe('');
+    });
+
+    it('should not trigger form value update if mask is changed when triggerOnMaskChange is false', async () => {
+        component.mask.set('00000||00000-0000');
+        component.triggerOnMaskChange.set(false);
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        equal('1234', '1234', fixture);
+        expect(inputTarget.value).toEqual('1234');
+        expect(component.form.value).toBe('1234');
+
+        component.mask.set('S0S 0S0');
+        equal(inputTarget.value, '', fixture, true);
+        expect(component.form.value).toBe('1234');
     });
 });


### PR DESCRIPTION
Ensure that "triggerOnMaskChange" and "shownMaskExpression" are received in "NgxMaskService" when provided through "provideNgxMask()".

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When values for "triggerOnMaskChange" and "shownMaskExpression" are provided through "provideNgxMask()", the configuration values don't flow through to the NgxMaskService and aren't applied to the <input> field.

Issue Number: N/A

## What is the new behavior?

Providing values for "triggerOnMaskChange" and "shownMaskExpression" through "provideNgxMask()" will inject the values into NgxMaskService which will be used when masking. For example:

```typescript
provideNgxMask({
  triggerOnMaskChange: true,
  showMaskTyped: true,
  shownMaskExpression: '0000'
})
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
