### PR TITLE
fix(1532): When precision is not specified on "separator" mask error …

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -801,7 +801,7 @@ export class NgxMaskService extends NgxMaskApplierService {
 
         if (
             separatorExpression.indexOf('2') > 0 ||
-            (this.leadZero && Number(separatorPrecision) > 0)
+            (this.leadZero && separatorPrecision != Infinity && Number(separatorPrecision) > 0)
         ) {
             if (this.decimalMarker === MaskExpression.COMMA && this.leadZero) {
                 value = value.replace(',', '.');

--- a/projects/ngx-mask-lib/src/test/mask.service.spec.ts
+++ b/projects/ngx-mask-lib/src/test/mask.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import {  NgxMaskService,provideNgxMask} from 'ngx-mask';
+
+describe('NgxMaskService', () => {
+  let service: NgxMaskService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideNgxMask(),
+        NgxMaskService
+      ]
+    });
+    service = TestBed.inject(NgxMaskService);
+  });
+
+  it('should not call toFixed with "separator" precision and leadZero is true', () => {
+    const originalToFixed = Number.prototype.toFixed;
+    const spy = spyOn(Number.prototype, 'toFixed').and.callFake(function (this: Number, digits: number) {
+      if (!isFinite(digits)) {
+        fail(` toFixed() called with invalid precision: ${digits}`);
+      }
+      return originalToFixed.call(this, digits);
+    });
+    service.leadZero = true;
+    service._checkPrecision('separator', '123456.78');
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Include additional logic to check if separatorPrecision is Infinity or not before checking if > 0

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #1532 

## What is the new behavior?

Additonal logic check for separatorPrecision

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
