### PR TITLE
fix(ref: 1560): added handling of "writingValue" variable to avoid th…

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -595,6 +595,10 @@ export class NgxMaskService extends NgxMaskApplierService {
             ? this.outputTransformFn
             : (v: unknown) => v;
 
+        if (this.writingValue) {
+            return;
+        }
+
         this.writingValue = false;
         this.maskChanged = false;
 


### PR DESCRIPTION
…e propagation of the changed value

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [1560](https://github.com/JsDaddy/ngx-mask/issues/1560)

The input / form is marked as dirty on initial load.

## What is the new behavior?

The input / form is not marked as dirty on initial load.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The initial load of the form changes the input value, but tries to avoid the propagation of the event to the angular model by setting "writingValue" to true. The comment on the function says "It won't do this if writingValue is true", but there was no handling of the variable in the code, except it was set to "false" every time.