### PR TITLE
feat(mask): add support for alphanumeric CNPJ format

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -425,6 +425,14 @@ You can hide symbols in input field and get the actual value in `formcontrol`.
 <input mask="CPF_CNPJ" />
 ```
 
+### CPF_CNPJ_ALPHA valid mask
+
+#### Usage
+
+```html
+<input mask="CPF_CNPJ_ALPHA" />
+```
+
 ### Allow few mask in one expression
 
 #### Usage

--- a/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask-applier.service.ts
@@ -136,11 +136,16 @@ export class NgxMaskApplierService {
                 arr.push(processedValue[i] ?? MaskExpression.EMPTY_STRING);
             }
         }
-        if (maskExpression === MaskExpression.CPF_CNPJ) {
+        const isCpfCnpjAlpha = maskExpression === MaskExpression.CPF_CNPJ_ALPHA;
+        if (maskExpression === MaskExpression.CPF_CNPJ || isCpfCnpjAlpha) {
             this.cpfCnpjError = arr.length !== 11 && arr.length !== 14;
-            if (arr.length > 11) {
+            const valueHasAnyLetter = /[a-zA-Z]/.test(processedValue);
+            if (valueHasAnyLetter && isCpfCnpjAlpha) {
                 // eslint-disable-next-line no-param-reassign
-                maskExpression = '00.000.000/0000-00';
+                maskExpression = 'AA.AAA.AAA/AAAA-00';
+            } else if (arr.length > 11) {
+                // eslint-disable-next-line no-param-reassign
+                maskExpression = isCpfCnpjAlpha ? 'AA.AAA.AAA/AAAA-00' : '00.000.000/0000-00';
             } else {
                 // eslint-disable-next-line no-param-reassign
                 maskExpression = '000.000.000-00';

--- a/projects/ngx-mask-lib/src/lib/ngx-mask-expression.enum.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask-expression.enum.ts
@@ -3,6 +3,7 @@ export const enum MaskExpression {
     PERCENT = 'percent',
     IP = 'IP',
     CPF_CNPJ = 'CPF_CNPJ',
+    CPF_CNPJ_ALPHA = 'CPF_CNPJ_ALPHA',
     MONTH = 'M',
     MONTHS = 'M0',
     MINUTE = 'm',

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -71,7 +71,10 @@ export class NgxMaskService extends NgxMaskApplierService {
         if (this.maskExpression === MaskExpression.IP && this.showMaskTyped) {
             this.maskIsShown = this.showMaskInInput(inputValue || MaskExpression.HASH);
         }
-        if (this.maskExpression === MaskExpression.CPF_CNPJ && this.showMaskTyped) {
+        const isCpfCnpjMask =
+            this.maskExpression === MaskExpression.CPF_CNPJ ||
+            this.maskExpression === MaskExpression.CPF_CNPJ_ALPHA;
+        if (isCpfCnpjMask && this.showMaskTyped) {
             this.maskIsShown = this.showMaskInInput(inputValue || MaskExpression.HASH);
         }
 
@@ -292,7 +295,8 @@ export class NgxMaskService extends NgxMaskApplierService {
             return `${result}${prefNmask.slice(resLen + countSkipedSymbol)}`;
         } else if (
             this.maskExpression === MaskExpression.IP ||
-            this.maskExpression === MaskExpression.CPF_CNPJ
+            this.maskExpression === MaskExpression.CPF_CNPJ ||
+            this.maskExpression === MaskExpression.CPF_CNPJ_ALPHA
         ) {
             return `${result}${prefNmask}`;
         }
@@ -435,7 +439,10 @@ export class NgxMaskService extends NgxMaskApplierService {
                 if (this.maskExpression === MaskExpression.IP) {
                     return this._checkForIp(inputVal);
                 }
-                if (this.maskExpression === MaskExpression.CPF_CNPJ) {
+                if (
+                    this.maskExpression === MaskExpression.CPF_CNPJ ||
+                    this.maskExpression === MaskExpression.CPF_CNPJ_ALPHA
+                ) {
                     return this._checkForCpfCnpj(inputVal);
                 }
             }
@@ -533,6 +540,9 @@ export class NgxMaskService extends NgxMaskApplierService {
         if (inputVal === MaskExpression.HASH) {
             return cpf;
         }
+
+        const isCpfCnpjAlpha = this.maskExpression === MaskExpression.CPF_CNPJ_ALPHA;
+        const hasAnyLetter = /[a-zA-Z]/.test(inputVal);
         const arr: string[] = [];
         // eslint-disable-next-line @typescript-eslint/prefer-for-of
         for (let i = 0; i < inputVal.length; i++) {
@@ -540,21 +550,25 @@ export class NgxMaskService extends NgxMaskApplierService {
             if (!value) {
                 continue;
             }
-            if (value.match('\\d')) {
+            if (!isCpfCnpjAlpha && value.match('\\d')) {
                 arr.push(value);
             }
         }
-        if (arr.length <= 3) {
-            return cpf.slice(arr.length, cpf.length);
-        }
-        if (arr.length > 3 && arr.length <= 6) {
-            return cpf.slice(arr.length + 1, cpf.length);
-        }
-        if (arr.length > 6 && arr.length <= 9) {
-            return cpf.slice(arr.length + 2, cpf.length);
-        }
-        if (arr.length > 9 && arr.length < 11) {
-            return cpf.slice(arr.length + 3, cpf.length);
+        if (isCpfCnpjAlpha && hasAnyLetter) {
+            return cnpj.slice(arr.length, cnpj.length);
+        } else {
+            if (arr.length <= 3) {
+                return cpf.slice(arr.length, cpf.length);
+            }
+            if (arr.length > 3 && arr.length <= 6) {
+                return cpf.slice(arr.length + 1, cpf.length);
+            }
+            if (arr.length > 6 && arr.length <= 9) {
+                return cpf.slice(arr.length + 2, cpf.length);
+            }
+            if (arr.length > 9 && arr.length < 11) {
+                return cpf.slice(arr.length + 3, cpf.length);
+            }
         }
         if (arr.length === 11) {
             return '';

--- a/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
+++ b/projects/ngx-mask-lib/src/test/basic-logic.spec.ts
@@ -251,6 +251,65 @@ describe('Directive: Mask', () => {
         equal('12.345.678/9012-34', '12.345.678/9012-34', fixture);
     });
 
+    it('Masks with CPF_CNPJ_ALPHA', () => {
+        component.mask.set('CPF_CNPJ_ALPHA');
+        equal('', '', fixture);
+        equal('1', '1', fixture);
+        equal('12', '12', fixture);
+        equal('123', '123', fixture);
+        equal('1234', '123.4', fixture);
+        equal('12345', '123.45', fixture);
+        equal('123456', '123.456', fixture);
+        equal('1234567', '123.456.7', fixture);
+        equal('12345678', '123.456.78', fixture);
+        equal('123456789', '123.456.789', fixture);
+        equal('1234567890', '123.456.789-0', fixture);
+        equal('12345678901', '123.456.789-01', fixture);
+        equal('123456789012', '12.345.678/9012', fixture);
+        equal('1234567890123', '12.345.678/9012-3', fixture);
+        equal('12345678901234', '12.345.678/9012-34', fixture);
+        equal('123.4', '123.4', fixture);
+        equal('123.45', '123.45', fixture);
+        equal('123.456', '123.456', fixture);
+        equal('123.4567', '123.456.7', fixture);
+        equal('123.456.78', '123.456.78', fixture);
+        equal('123.456.789', '123.456.789', fixture);
+        equal('123.456.789-0', '123.456.789-0', fixture);
+        equal('123.456.789-01', '123.456.789-01', fixture);
+        equal('12.345.678/9012', '12.345.678/9012', fixture);
+        equal('12.345.678/9012-3', '12.345.678/9012-3', fixture);
+        equal('12.345.678/9012-34', '12.345.678/9012-34', fixture);
+        equal('A', 'A', fixture);
+        equal('AB', 'AB', fixture);
+        equal('ABC', 'AB.C', fixture);
+        equal('ABCD', 'AB.CD', fixture);
+        equal('ABCDE', 'AB.CDE', fixture);
+        equal('ABCDEF', 'AB.CDE.F', fixture);
+        equal('ABCDEF0', 'AB.CDE.F0', fixture);
+        equal('ABCDEF01', 'AB.CDE.F01', fixture);
+        equal('ABCDEF012', 'AB.CDE.F01/2', fixture);
+        equal('ABCDEF0123', 'AB.CDE.F01/23', fixture);
+        equal('ABCDEF01234', 'AB.CDE.F01/234', fixture);
+        equal('ABCDEF012345', 'AB.CDE.F01/2345', fixture);
+        equal('ABCDEF0123456', 'AB.CDE.F01/2345-6', fixture);
+        equal('ABCDEF01234567', 'AB.CDE.F01/2345-67', fixture);
+        equal('AB.C', 'AB.C', fixture);
+        equal('AB.CD', 'AB.CD', fixture);
+        equal('AB.CDE', 'AB.CDE', fixture);
+        equal('AB.CDE.F', 'AB.CDE.F', fixture);
+        equal('AB.CDE.F0', 'AB.CDE.F0', fixture);
+        equal('AB.CDE.F01', 'AB.CDE.F01', fixture);
+        equal('AB.CDE.F01/2', 'AB.CDE.F01/2', fixture);
+        equal('AB.CDE.F01/23', 'AB.CDE.F01/23', fixture);
+        equal('AB.CDE.F01/234', 'AB.CDE.F01/234', fixture);
+        equal('AB.CDE.F01/2345', 'AB.CDE.F01/2345', fixture);
+        equal('AB.CDE.F01/2345-6', 'AB.CDE.F01/2345-6', fixture);
+        equal('AB.CDE.F01/2345-67', 'AB.CDE.F01/2345-67', fixture);
+
+        equal('0123456789', '012.345.678-9', fixture);
+        equal('0123456789A', '01.234.567/89A', fixture);
+    });
+
     it('Dynamic Masks CPF_CNPJ', () => {
         component.mask.set('000.000.000-00||00.000.000/0000-00');
         equal('', '', fixture);

--- a/projects/ngx-mask-lib/src/test/place-holder-character.spec.ts
+++ b/projects/ngx-mask-lib/src/test/place-holder-character.spec.ts
@@ -56,6 +56,25 @@ describe('Directive: Mask (Placeholder character)', () => {
         equal('1234567890123', '12.345.678/9012-3_', fixture);
         equal('12345678901234', '12.345.678/9012-34', fixture);
 
+        component.mask.set('CPF_CNPJ_ALPHA');
+        component.prefix.set('');
+        component.showMaskTyped.set(true);
+        equal('', '___.___.___-__', fixture);
+        equal('A', 'A_.___.___/____-__', fixture);
+        equal('AB', 'AB.___.___/____-__', fixture);
+        equal('ABC', 'AB.C__.___/____-__', fixture);
+        equal('ABCD', 'AB.CD_.___/____-__', fixture);
+        equal('ABCDE', 'AB.CDE.___/____-__', fixture);
+        equal('ABCDEF', 'AB.CDE.F__/____-__', fixture);
+        equal('ABCDEF0', 'AB.CDE.F0_/____-__', fixture);
+        equal('ABCDEF01', 'AB.CDE.F01/____-__', fixture);
+        equal('ABCDEF012', 'AB.CDE.F01/2___-__', fixture);
+        equal('ABCDEF0123', 'AB.CDE.F01/23__-__', fixture);
+        equal('ABCDEF01234', 'AB.CDE.F01/234_-__', fixture);
+        equal('ABCDEF012345', 'AB.CDE.F01/2345-__', fixture);
+        equal('ABCDEF0123456', 'AB.CDE.F01/2345-6_', fixture);
+        equal('ABCDEF01234567', 'AB.CDE.F01/2345-67', fixture);
+
         component.mask.set('000.000.000-00||00.000.000/0000-00');
         component.prefix.set('');
         component.showMaskTyped.set(true);


### PR DESCRIPTION
Add new CPF_CNPJ_ALPHA mask expression to support the new alphanumeric CNPJ format introduced by the Brazilian Federal Revenue Service. The mask automatically switches between CPF format (###.###.###-##) and alphanumeric CNPJ format (AA.AAA.AAA/AAAA-##) based on input content.

Ref: https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
