### PR TITLE
fix(ref:1601): Relax FormValueControl implementation

### DIFF
--- a/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.directive.ts
@@ -10,6 +10,7 @@ import {
     HostListener,
     inject,
     untracked,
+    booleanAttribute,
 } from '@angular/core';
 import type {
     ControlValueAccessor,
@@ -18,7 +19,7 @@ import type {
     Validator,
 } from '@angular/forms';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { FormValueControl, ValidationError, WithOptionalField } from '@angular/forms/signals';
+import type { FormValueControl } from '@angular/forms/signals';
 
 import type { NgxMaskConfig } from './ngx-mask.config';
 import { NGX_MASK_CONFIG, timeMasks, withoutValidation } from './ngx-mask.config';
@@ -73,15 +74,8 @@ export class NgxMaskDirective
     public instantPrefix = input<NgxMaskConfig['instantPrefix'] | null>(null);
 
     public value = model<string>('');
-    public errors = input<readonly WithOptionalField<ValidationError>[]>([]);
-    public disabled = input<boolean>(false);
+    public disabled = input(false, { transform: booleanAttribute });
     public touched = model<boolean>(false);
-    public dirty = input<boolean>(false);
-    public invalid = input<boolean>(false);
-    public pending = input<boolean>(false);
-    public readonly = input<boolean>(false);
-    public required = input<boolean>(false);
-    public name = input<string>('');
 
     public maskFilled = output<void>();
 


### PR DESCRIPTION
Relaxes the Angular signal form interface implementation to avoid conflicts with other directives or the host component, e.g., for required and readonly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #1601 

## What is the new behavior?

Only used parts of the `FormValueControl` interface are implemented.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

N/A