### PR TITLE
ci(quality): run build and quality only on pull requests to develop

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,10 +38,13 @@ jobs:
               env:
                   RELEASE_VERSION: ${{ steps.semantic-release.outputs.new-release-version }}
               run: |
+                  if [ -z "$RELEASE_VERSION" ]; then
+                      RELEASE_VERSION=$(node -p "require('./projects/ngx-mask-lib/package.json').version")
+                  fi
                   echo '********'
                   echo "RELEASE_VERSION: $RELEASE_VERSION"
                   echo '********'
-                  bash .github/workflows/scripts/replace_template.sh $RELEASE_VERSION
+                  bash .github/workflows/scripts/replace_template.sh "$RELEASE_VERSION"
                   bun run build
 
             - name: Deploy demo

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,26 +1,13 @@
 name: build and quality
 
 on:
-    push:
-        branches:
-            - '**'
     pull_request:
         branches:
-            - main
             - develop
         types: [opened, synchronize, reopened]
 
 jobs:
-    should-run:
-        runs-on: ubuntu-latest
-        outputs:
-            should-run-check: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
-        steps:
-            - run: echo "Checking if workflow should run"
-
     quality-check:
-        needs: should-run
-        if: needs.should-run.outputs.should-run-check == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
## Summary
- Dropped the `push: branches: '**'` trigger and the `should-run` dedup job from the quality-check workflow
- The workflow now runs on a single trigger: `pull_request` targeting `develop`

## Why
Running on every branch push in addition to pull requests caused duplicate CI runs (push + PR both firing). The PR check to `develop` is now the single required gate.

## Test plan
- [ ] Confirm the quality-check check appears and passes on this PR